### PR TITLE
Allow for faster travis builds with container based infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,18 @@ python:
   - '3.4'
   - "nightly"
 
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - ant
 
 env:
   matrix:
     # one build with and without numpy support (opt numpy out)
     - NUMPY="--install-option=--disable-numpy"
     - NUMPY=""
-
-before_install:
-  - sudo apt-get install -qq ant
 
 install:
   - pip install . $NUMPY


### PR DESCRIPTION
See http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/ and http://blog.travis-ci.com/2015-03-31-docker-default-on-the-way/