### PR TITLE
FIX ImportError on import _winreg

### DIFF
--- a/jpype/_windows.py
+++ b/jpype/_windows.py
@@ -16,7 +16,10 @@
 #*****************************************************************************
 
 from . import _jvmfinder
-import _winreg as winreg
+try:
+    import _winreg as winreg
+except ImportError:
+    import winreg  # in Py3, winreg has been moved
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
In python 3 `_winreg` is renamed to `winreg`. This fixes the `ImportError`.