### PR TITLE
Add unit test to fix for Collection iteration

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Huge thanks to these CONTRIBUTORS:
 * Bastian Bowe
 * Kristi
 * Martin K. Scherer
+* Dongwon Shin

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -9,6 +9,8 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
   - Fix Python 3 support for Windows failing to import winreg.
 
+  - Fix non matching overloads on iterating java collections.
+
 - **0.6.0 - 2015-04-13**
 
   - Python3 support.

--- a/jpype/_jcollection.py
+++ b/jpype/_jcollection.py
@@ -247,7 +247,7 @@ def _iterIter(self):
 class IteratorCustomizer(object):
     _METHODS = {
         '__iter__': _iterIter,
-        '__next__': _iterIteratorNext,
+        '__next__': _iterCustomNext,
     }
 
     def canCustomize(self, name, jc):
@@ -259,10 +259,7 @@ class IteratorCustomizer(object):
         if name == 'java.util.Iterator':
             members.update(IteratorCustomizer._METHODS)
         elif jc.isSubclass('java.util.Iterator'):
-            __next__ = '__next__'
-            if 'next' in members:
-                __next__ = 'next'
-
+            __next__ = 'next' if 'next' in members else '__next__'
             members['_next'] = members[__next__]
             members[__next__] = _iterCustomNext
 

--- a/jpype/_jcollection.py
+++ b/jpype/_jcollection.py
@@ -259,11 +259,12 @@ class IteratorCustomizer(object):
         if name == 'java.util.Iterator':
             members.update(IteratorCustomizer._METHODS)
         elif jc.isSubclass('java.util.Iterator'):
+            __next__ = '__next__'
             if 'next' in members:
-                members['_next'] = members['next']
-            elif '__next__' in members:
-                members['_next'] = members['__next__']
-            members['__next__'] = _iterCustomNext
+                __next__ = 'next'
+
+            members['_next'] = members[__next__]
+            members[__next__] = _iterCustomNext
 
 def _enumNext(self):
     if self.hasMoreElements():

--- a/test/jpypetest/collection.py
+++ b/test/jpypetest/collection.py
@@ -1,0 +1,13 @@
+import jpype
+from . import common
+
+class CollectionTestCase(common.JPypeTestCase):
+
+    def setUp(self):
+        super(CollectionTestCase, self).setUp()
+
+    def testCollection(self):
+        collection = jpype.java.util.ArrayList()
+        collection.add(1)
+        collection.add(2)
+        self.assertEqual([1, 2], list(collection))

--- a/test/jpypetest/collection.py
+++ b/test/jpypetest/collection.py
@@ -10,4 +10,4 @@ class CollectionTestCase(common.JPypeTestCase):
         collection = jpype.java.util.ArrayList()
         collection.add(1)
         collection.add(2)
-        self.assertEqual([1, 2], list(collection))
+        self.assertEqual([1, 2], [i for i in collection])


### PR DESCRIPTION
This adds unit tests for PR #143 which fixes #142 which fixes iteration problems on java collections (no method overloads found).

Please do not merge this PR now as I don't understand what 9e88eef is for. I would love to add unit tests for that commit too. @littmus please provide some more information on that commit.