### PR TITLE
suppose long when converting to java

### DIFF
--- a/native/common/jp_primitivetypes.cpp
+++ b/native/common/jp_primitivetypes.cpp
@@ -336,13 +336,13 @@ EMatchType JPLongType::canConvertToJava(HostRef* obj)
 jvalue JPLongType::convertToJava(HostRef* obj)
 {
 	jvalue res;
-	if (JPEnv::getHost()->isInt(obj))
-	{
-		res.j = (jlong)JPEnv::getHost()->intAsInt(obj);
-	}
-	else if (JPEnv::getHost()->isLong(obj))
+	if (JPEnv::getHost()->isLong(obj))
 	{
 		res.j = (jlong)JPEnv::getHost()->longAsLong(obj);
+	}
+	else if (JPEnv::getHost()->isInt(obj))
+	{
+		res.j = (jlong)JPEnv::getHost()->intAsInt(obj);
 	}
 	else if (JPEnv::getHost()->isWrapper(obj))
 	{


### PR DESCRIPTION
Python 3 does not have long type, which results an overflow when convert it to java long if it is too long