### PR TITLE
Fix MRO problems with interface hierarchies

### DIFF
--- a/test/harness/jpype/mro/MultipleInterfaces.java
+++ b/test/harness/jpype/mro/MultipleInterfaces.java
@@ -1,0 +1,29 @@
+//*****************************************************************************
+//   Copyright 2004-2008 Steve Menard
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//*****************************************************************************
+package jpype.mro;
+
+interface IA {}
+interface IB {}
+
+
+interface ICombined1 extends IA,IB {}
+interface ICombined2 extends IB,IA {}
+
+
+public class MultipleInterfaces implements ICombined1, ICombined2 {
+    public MultipleInterfaces() {}
+}

--- a/test/jpypetest/mro.py
+++ b/test/jpypetest/mro.py
@@ -21,3 +21,7 @@ from . import common
 class MroTestCase(common.JPypeTestCase):
     def testMro(self):
         C = JPackage('jpype.mro').C
+
+    def testMultipleInterfaces(self):
+        j = JPackage("jpype").mro.MultipleInterfaces
+        myinstance = j()


### PR DESCRIPTION
The test in mro.py demonstrates the problem leading to the classic mro error. In larger interface hierarchies this problem can be hidden far down in the hierarchy such that one cannot only drop duplicates from the immedate bases as was done until now. Using a metaclass the mro is replaced by a simple topsort of the hierarchy.

Quite likely also Issue #159 is fixed by this change. 

(its my first step on github so please advice if i should have done something different)