### PR TITLE
fix calls from python to methods taking integer/long primitives for larger intergers

### DIFF
--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -46,7 +46,7 @@
 
 #ifdef WIN32
 	#ifdef __GNUC__
-		// JNICALL causes problem for funtions prototypes .. since I am nto defining any JNI methods there isno need for it
+		// JNICALL causes problem for function prototypes .. since I am not defining any JNI methods there is no need for it
 		#undef JNICALL
 		#define JNICALL
 	#endif

--- a/native/common/jp_primitivetypes.cpp
+++ b/native/common/jp_primitivetypes.cpp
@@ -86,6 +86,7 @@ jvalue JPByteType::convertToJava(HostRef* obj)
 		if (l < JPJni::s_minByte || l > JPJni::s_maxByte)
 		{
 			JPEnv::getHost()->setTypeError("Cannot convert value to Java byte");
+			JPEnv::getHost()->raise("JPByteType::convertToJava");
 		}
 		res.b = (jbyte)l;
 	}
@@ -95,6 +96,7 @@ jvalue JPByteType::convertToJava(HostRef* obj)
 		if (l < JPJni::s_minByte || l > JPJni::s_maxByte)
 		{
 			JPEnv::getHost()->setTypeError("Cannot convert value to Java byte");
+			JPEnv::getHost()->raise("JPByteType::convertToJava");
 		}
 		res.b = (jbyte)l;
 	}
@@ -181,6 +183,7 @@ jvalue JPShortType::convertToJava(HostRef* obj)
 		if (l < JPJni::s_minShort || l > JPJni::s_maxShort)
 		{
 			JPEnv::getHost()->setTypeError("Cannot convert value to Java short");
+			JPEnv::getHost()->raise("JPShortType::convertToJava");
 		}
 
 		res.s = (jshort)l;
@@ -191,6 +194,7 @@ jvalue JPShortType::convertToJava(HostRef* obj)
 		if (l < JPJni::s_minShort || l > JPJni::s_maxShort)
 		{
 			JPEnv::getHost()->setTypeError("Cannot convert value to Java short");
+			JPEnv::getHost()->raise("JPShortType::convertToJava");
 		}
 		res.s = (jshort)l;
 	}
@@ -260,6 +264,7 @@ jvalue JPIntType::convertToJava(HostRef* obj)
 		if (l < JPJni::s_minInt || l > JPJni::s_maxInt)
 		{
 			JPEnv::getHost()->setTypeError("Cannot convert value to Java int");
+			JPEnv::getHost()->raise("JPIntType::convertToJava");
 		}
 
 		res.i = (jint)l;
@@ -270,6 +275,7 @@ jvalue JPIntType::convertToJava(HostRef* obj)
 		if (l < JPJni::s_minInt || l > JPJni::s_maxInt)
 		{
 			JPEnv::getHost()->setTypeError("Cannot convert value to Java int");
+			JPEnv::getHost()->raise("JPIntType::convertToJava");
 		}
 		res.i = (jint)l;
 	}
@@ -322,7 +328,7 @@ EMatchType JPLongType::canConvertToJava(HostRef* obj)
 	if (JPEnv::getHost()->isWrapper(obj))
 	{
 		JPTypeName name = JPEnv::getHost()->getWrapperTypeName(obj);
-		if (name.getType() == JPTypeName::_int)
+		if (name.getType() == JPTypeName::_long)
 		{
 			return _exact;
 		}
@@ -347,6 +353,12 @@ jvalue JPLongType::convertToJava(HostRef* obj)
 	else if (JPEnv::getHost()->isWrapper(obj))
 	{
 		return JPEnv::getHost()->getWrapperValue(obj);
+	}
+	else
+	{
+		JPEnv::getHost()->setTypeError("Cannot convert value to Java long");
+		JPEnv::getHost()->raise("JPLongType::convertToJava");
+		res.j = 0; // never reached
 	}
 	return res;
 }
@@ -407,10 +419,12 @@ jvalue JPFloatType::convertToJava(HostRef* obj)
 		if (l > 0 && (l < JPJni::s_minFloat || l > JPJni::s_maxFloat))
 		{
 			JPEnv::getHost()->setTypeError("Cannot convert value to Java float");
+			JPEnv::getHost()->raise("JPFloatType::convertToJava");
 		}
 		else if (l < 0 && (l > -JPJni::s_minFloat || l < -JPJni::s_maxFloat))
 		{
 			JPEnv::getHost()->setTypeError("Cannot convert value to Java float");
+			JPEnv::getHost()->raise("JPFloatType::convertToJava");
 		}
 		res.f = (jfloat)l;
 	}
@@ -576,7 +590,7 @@ HostRef* JPBooleanType::asHostObjectFromObject(jvalue val)
 
 EMatchType JPBooleanType::canConvertToJava(HostRef* obj)
 {
-	if (JPEnv::getHost()->isInt(obj))
+	if (JPEnv::getHost()->isInt(obj) || JPEnv::getHost()->isLong(obj))
 	{
 		return _implicit;
 	}
@@ -599,6 +613,10 @@ jvalue JPBooleanType::convertToJava(HostRef* obj)
 	if (JPEnv::getHost()->isWrapper(obj))
 	{
 		return JPEnv::getHost()->getWrapperValue(obj);
+	}
+	else if (JPEnv::getHost()->isLong(obj))
+	{
+		res.z = (jboolean)JPEnv::getHost()->longAsLong(obj);
 	}
 	else
 	{

--- a/native/python/jpype_javaarray.cpp
+++ b/native/python/jpype_javaarray.cpp
@@ -134,7 +134,8 @@ PyObject* JPypeJavaArray::getArraySlice(PyObject* self, PyObject* arg)
 		else if (hi > length) hi = length;
 		if (lo > hi) lo = hi;
 
-		const string& name = a->getType()->getObjectType().getComponentName().getNativeName();
+		const JPTypeName& componentName = a->getType()->getObjectType().getComponentName();
+		const string& name = componentName.getNativeName();
 		if(is_primitive(name[0]))
 		{
 			// for primitive types, we have fast sequence generation available
@@ -183,7 +184,8 @@ PyObject* JPypeJavaArray::setArraySlice(PyObject* self, PyObject* arg)
 		else if (hi > length) hi = length;
 		if (lo > hi) lo = hi;
 
-		const string& name = a->getType()->getObjectType().getComponentName().getNativeName();
+		const JPTypeName& componentName = a->getType()->getObjectType().getComponentName();
+		const string& name = componentName.getNativeName();
 
 		if(is_primitive(name[0]))
 		{

--- a/native/python/py_method.cpp
+++ b/native/python/py_method.cpp
@@ -284,12 +284,11 @@ int PyJPBoundMethod::__init__(PyObject* o, PyObject* args, PyObject* kwargs)
 		Py_INCREF(javaMethod);
 		self->m_Instance = inst;
 		self->m_Method = (PyJPMethod*)javaMethod;
-
 		return 0;
 	}
 	PY_STANDARD_CATCH
 
-	return 1;
+	return -1;
 }
 
 PyObject* PyJPBoundMethod::__call__(PyObject* o, PyObject* args, PyObject* kwargs)
@@ -336,8 +335,8 @@ void PyJPBoundMethod::__dealloc__(PyObject* o)
 	TRACE_IN("PyJPBoundMethod::__dealloc__");
 	PyJPBoundMethod* self = (PyJPBoundMethod*)o;
 
-	Py_DECREF(self->m_Instance);
-	Py_DECREF(self->m_Method);
+	Py_XDECREF(self->m_Instance);
+	Py_XDECREF(self->m_Method);
 
 	Py_TYPE(self)->tp_free(o);
 	TRACE1("Method freed");

--- a/test/harness/jpype/attr/Test1.java
+++ b/test/harness/jpype/attr/Test1.java
@@ -83,17 +83,36 @@ public class Test1
 		
 	}
 	
+	boolean mBooleanValue = false;
+	public void setBoolean(boolean b)
+	{
+		mBooleanValue = b;
+	}
+	
+	byte mByteValue;
 	public void setByte(byte b)
 	{
+		mByteValue = b;
 	}
 
-	public void setShort(short b)
+	short mShortValue = 0;
+	public void setShort(short s)
 	{
+		mShortValue = s;
 	}
 
-	public void setInt(int b)
+	int mIntValue = 0;
+	public void setInt(int i)
 	{
+		mIntValue = i;
 	}
+
+	long mLongValue = 0;
+	public void setLong(long l)
+	{
+		mLongValue = l;
+	}
+	
 	
 	public String callWithSomething(Object obj)
 	{

--- a/test/jpypetest/attr.py
+++ b/test/jpypetest/attr.py
@@ -127,9 +127,69 @@ class AttributeTestCase(common.JPypeTestCase):
             l = long(123)
 
         h.setByte(l)
+        self.assertEqual(l, h.mByteValue)
         h.setShort(l)
+        self.assertEqual(l, h.mShortValue)
         h.setInt(l)
+        self.assertEqual(l, h.mIntValue)
+        h.setLong(l)
+        self.assertEqual(l, h.mLongValue)
 
+    def testCallWithBigLong(self):
+        h = self.__jp.Test1()
+        if sys.version > '3':
+            l = int(4398046511103)
+        else:
+            l = long(4398046511103)
+ 
+        self.assertRaises(TypeError, h.setByte, l)
+        self.assertRaises(TypeError, h.setShort, l)
+        self.assertRaises(TypeError, h.setInt, l)
+        h.setLong(l)
+        self.assertEqual(l, h.mLongValue)
+
+    def testCallWithBigInt(self):
+        h = self.__jp.Test1()
+        if sys.version > '3' or sys.maxint > 2**31:
+            l = int(4398046511103)
+        else:
+            l = long(4398046511103)
+ 
+        self.assertRaises(TypeError, h.setByte, l)
+        self.assertRaises(TypeError, h.setShort, l)
+        self.assertRaises(TypeError, h.setInt, l)
+        h.setLong(l)
+        self.assertEqual(l, h.mLongValue)
+
+    def testSetBoolean(self):
+        h = self.__jp.Test1()
+        self.assertEqual(False, h.mBooleanValue)
+        h.setBoolean(True)
+        self.assertEqual(True, h.mBooleanValue)
+        h.setBoolean(False)
+        self.assertEqual(False, h.mBooleanValue)
+        # just testing the status quo, not sure about if this is nice
+        h.setBoolean(42)
+        self.assertEqual(True, h.mBooleanValue)
+        h.setBoolean(0)
+        self.assertEqual(False, h.mBooleanValue)
+        if sys.version > '3':
+            l = int(4398046511103)
+        else:
+            l = long(4398046511103)
+        h.setBoolean(l)
+        self.assertEqual(True, h.mBooleanValue)
+        if sys.version > '3':
+            l = int(0)
+        else:
+            l = long(0)
+        h.setBoolean(l)
+        self.assertEqual(False, h.mBooleanValue)
+
+    def testCreateDate(self):
+        d = jpype.java.util.Date(1448799485000)
+        self.assertEqual(1448799485000, d.getTime())
+        
     def testCharAttribute(self):
         h = self.__jp.Test1()
         h.charValue = u'b'
@@ -204,3 +264,4 @@ class AttributeTestCase(common.JPypeTestCase):
         free = rt.freeMemory()
         for x in range(0, 10 * free // block_size):
             allocate_then_free()
+        

--- a/test/jpypetest/numeric.py
+++ b/test/jpypetest/numeric.py
@@ -14,8 +14,9 @@
 #   limitations under the License.
 #
 #*****************************************************************************
-from jpype import JPackage, java, JFloat
+from jpype import JPackage, java, JFloat, JByte, JShort, JInt, JLong
 from . import common
+import sys
 
 class NumericTestCase(common.JPypeTestCase):
     def testMathAbs(self):
@@ -34,3 +35,50 @@ class NumericTestCase(common.JPypeTestCase):
 
     def testNegativeJFloatWrapper(self):
         f = JFloat(-1)
+
+    def checkJWrapper(self, min_value, max_value, javawrapper, jwrapper, expected=TypeError):
+        self.assertEqual(max_value, javawrapper(max_value).longValue())
+        f = jwrapper(max_value)
+        self.assertEqual(max_value, javawrapper(f).longValue())
+
+        self.assertEqual(min_value, javawrapper(min_value).longValue())
+        f = jwrapper(min_value)
+        self.assertEqual(min_value, javawrapper(f).longValue())
+        
+        self.assertRaises(expected, javawrapper, max_value+1)
+        self.assertRaises(expected, jwrapper, max_value+1)
+        self.assertRaises(expected, javawrapper, min_value-1)
+        self.assertRaises(expected, jwrapper, min_value-1)
+
+        # test against int overflow
+        if(max_value < 2**32):
+            self.assertRaises(expected, javawrapper, 2**32)
+            self.assertRaises(expected, jwrapper, 2**32)
+
+    def testJCharWrapper(self):
+        self.checkJWrapper(-2**7, 2**7-1, java.lang.Byte, JByte)
+
+    def testJByteWrapper(self):
+        self.checkJWrapper(-2**7, 2**7-1, java.lang.Byte, JByte)
+
+    def testJShortWrapper(self):
+        self.checkJWrapper(-2**15, 2**15-1, java.lang.Short, JShort)
+
+    def testJIntWrapper(self):
+        self.checkJWrapper(-2**31, 2**31-1, java.lang.Integer, JInt)
+
+    def testJLongWrapper(self):
+        self.checkJWrapper(-2**63, 2**63-1, java.lang.Long, JLong, OverflowError)
+        
+    def testJFloatWrapper(self):
+        jwrapper = JFloat
+        javawrapper = java.lang.Float
+        jwrapper(float(2**127))
+        javawrapper(float(2**127))
+        self.assertRaises(TypeError, jwrapper, float(2**128))
+        # this difference might be undesirable, 
+        # a double bigger than maxfloat passed to java.lang.Float turns into infinity 
+        self.assertEquals(float('inf'), javawrapper(float(2**128)).doubleValue())
+        self.assertEquals(float('-inf'), javawrapper(float(-2**128)).doubleValue())
+        
+        


### PR DESCRIPTION
the most debatable changes in this PR are to `PythonHostEnvironment::isInt` and `PythonHostEnvironment::isLong`. the reason here is that on some platforms -- even with python2 -- integers have 64bit. if they are then returned in `jint PythonHostEnvironment::intAsInt` they get truncated. therefore calls with larger integers (>=2^31 or < -2^31) were broken. initially i though #156 was a good fix, but there was much more to this.  

i added couple of tests which cover the fixes. i started from jpypetest.attr.testCreateDate which is a very basic test.

i am happy to rework this change and would be glad if somebody could review it.

details from the commit:
   * overload resolution with JLong wrapper did not work (was checking for _int instead of _long)
   * on 64bit linux systems LONG_MAX is 2^63-1 and therefore returning JPyInt::asLong as a jint cuts of higher bits for values >= 2^31 or < -2^31
   * similar problem as above for all py3 on all systems as we have no long type anymore but only int
   * if a python exception was set we need to throw a PythonException not a JPypeException otherwise the message is overwritten
   * ref to member of temporary fixed in jpype_javaarray
   * tp_init has to either return 0 or -1