### PR TITLE
Fix Windows numpy bug

### DIFF
--- a/native/python/jpype_javaarray.cpp
+++ b/native/python/jpype_javaarray.cpp
@@ -134,7 +134,9 @@ PyObject* JPypeJavaArray::getArraySlice(PyObject* self, PyObject* arg)
 		else if (hi > length) hi = length;
 		if (lo > hi) lo = hi;
 
-		const string& name = a->getType()->getObjectType().getComponentName().getNativeName();
+		// writing this on two lines fixes Windows numpy bug
+		auto cname = a->getType()->getObjectType().getComponentName();
+		const string& name = cname.getNativeName();
 		if(is_primitive(name[0]))
 		{
 			// for primitive types, we have fast sequence generation available


### PR DESCRIPTION
The following edit seems to fix issue #133, which causes JPype on Windows to convert Java array slices to lists, even when NumPy support is enabled. I'm not sure why this fix works, but it solves the issue on my machine.