### PR TITLE
Fix Windows bug ignoring NumPy when getting and setting array slices

### DIFF
--- a/native/python/jpype_javaarray.cpp
+++ b/native/python/jpype_javaarray.cpp
@@ -134,7 +134,7 @@ PyObject* JPypeJavaArray::getArraySlice(PyObject* self, PyObject* arg)
 		else if (hi > length) hi = length;
 		if (lo > hi) lo = hi;
 
-		const string& name = a->getType()->getObjectType().getComponentName().getNativeName();
+		const string name = a->getType()->getObjectType().getComponentName().getNativeName();
 		if(is_primitive(name[0]))
 		{
 			// for primitive types, we have fast sequence generation available
@@ -183,7 +183,7 @@ PyObject* JPypeJavaArray::setArraySlice(PyObject* self, PyObject* arg)
 		else if (hi > length) hi = length;
 		if (lo > hi) lo = hi;
 
-		const string& name = a->getType()->getObjectType().getComponentName().getNativeName();
+		const string name = a->getType()->getObjectType().getComponentName().getNativeName();
 
 		if(is_primitive(name[0]))
 		{


### PR DESCRIPTION
Bugfix for Issue #133: on Windows, JPype converts array slices to lists even when NumPy is installed. The bug occurs because JPype stores the name of the array object type in a temporary string, which gets deleted before it can be read. Making a local copy of the string fixes the bug.