### PR TITLE
improved overload resolution and support for java8 default methods

### DIFF
--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -198,7 +198,7 @@ function unzipAnt($file, $destination) {
 }
 
 function DownloadAnt() {
-    $url = "http://www.us.apache.org/dist/ant/binaries/apache-ant-1.9.4-bin.zip"
+    $url = "http://www.us.apache.org/dist/ant/binaries/apache-ant-1.9.6-bin.zip"
     $webclient = New-Object System.Net.WebClient
     $filepath = "C:\ant.zip"
 	

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -140,7 +140,7 @@ class _JavaClass(type):
         if name == 'java.lang.Object' or jc.isPrimitive():
             bases.append(object)
         elif not jc.isInterface():
-            bjc = jc.getBaseClass(jc)
+            bjc = jc.getBaseClass()
             bases.append(_getClassFor(bjc))
 
         if _JAVATHROWABLE is not None and jc.isSubclass("java.lang.Throwable"):

--- a/native/common/include/jp_classbase.h
+++ b/native/common/include/jp_classbase.h
@@ -37,7 +37,7 @@ public : // JPType implementation
 		return m_Name;
 	}
 
-	virtual jclass getClass()
+	virtual jclass getClass() const
 	{
 		return (jclass)JPEnv::getJava()->NewLocalRef(m_Class);
 	}

--- a/native/common/include/jp_jniutil.h
+++ b/native/common/include/jp_jniutil.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
-   Copyright 2004 Steve Ménard
+   Copyright 2004 Steve MÃ©nard
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
-*****************************************************************************/   
+
+*****************************************************************************/
 #ifndef _JPJNIUTIL_H_
 #define _JPJNIUTIL_H_
 
@@ -45,7 +45,7 @@ namespace JPJni
 	JCharString unicodeFromJava(jstring str);
 
 	jstring javaStringFromJCharString(JCharString& str);
-	
+
 	JPTypeName getClassName(jobject obj);
 	jclass getClass(jobject obj);
 	jstring toString(jobject obj);
@@ -105,7 +105,7 @@ namespace JPJni
 	* java.lang.Class.getDeclaredMethods()
 	*/
 	vector<jobject> getDeclaredConstructors(jclass);
-	
+
 	/**
 	* java.lang.Class.getModifiers()
 	*/
@@ -117,7 +117,7 @@ namespace JPJni
 	* java.lang.reflect.Member.getName()
 	*/
 	string getMemberName(jobject);
-	
+
 	/**
 	* java.lang.reflect.Modifier.isPublic(java.lang.reflect.member.getModifiers())
 	*/
@@ -134,7 +134,7 @@ namespace JPJni
 	bool isMemberFinal(jobject);
 
 	/**
-	* java.lang.reflect.Modifier.is(java.lang.reflect.member.getModifiers())
+	* java.lang.reflect.Modifier.isAbstract(java.lang.reflect.member.getModifiers())
 	*/
 	bool isMemberAbstract(jobject);
 
@@ -147,7 +147,17 @@ namespace JPJni
 	* java.lang.reflect.Method.getReturnType
 	*/
 	JPTypeName getReturnType(jobject);
-	
+
+	/**
+	* java.lang.reflect.Method.isSynthetic()
+	*/
+	bool isMethodSynthetic(jobject);
+
+	/**
+	* java.lang.reflect.Method.isSynthetic()
+	*/
+	bool isVarArgsMethod(jobject);
+
 	jint hashCode(jobject);
 
 	/**

--- a/native/common/include/jp_method.h
+++ b/native/common/include/jp_method.h
@@ -56,6 +56,7 @@ public :
 	string describe(string prefix);
 
 	string matchReport(vector<HostRef*>&);
+	void ensureOverloadOrderCache();
 
 private :
 	JPMethodOverload* findOverload(vector<HostRef*>& arg, bool needStatic);
@@ -63,6 +64,14 @@ private :
 	jclass                        m_Class;
 	string                        m_Name;
 	map<string, JPMethodOverload> m_Overloads;
+
+	struct OverloadData {
+		OverloadData(JPMethodOverload* o) : m_Overload(o) {}
+
+		JPMethodOverload*              m_Overload;
+		std::vector<JPMethodOverload*> m_MoreSpecificOverloads;
+	};
+	std::vector<OverloadData>     m_OverloadOrderCache;
 	bool                          m_IsConstructor;
 	
 };

--- a/native/common/include/jp_methodoverload.h
+++ b/native/common/include/jp_methodoverload.h
@@ -38,12 +38,12 @@ public :
 public :	
 	string getSignature();
 
-	bool isStatic()
+	bool isStatic() const
 	{
 		return m_IsStatic;
 	}
 	
-	bool isFinal()
+	bool isFinal() const
 	{
 		return m_IsFinal;
 	}
@@ -53,7 +53,7 @@ public :
 		return m_ReturnType;
 	}
 
-	unsigned char getArgumentCount()
+	unsigned char getArgumentCount() const
 	{
 		return (unsigned char)m_Arguments.size();
 	}
@@ -62,16 +62,20 @@ public :
 
 	bool isSameOverload(JPMethodOverload& o);
 	string matchReport(vector<HostRef*>& args);
-
+	bool isMoreSpecificThan(JPMethodOverload& other) const;
+private:
+	void ensureTypeCache() const;
 private :
-	JPClass*               m_Class;
-	jobject                m_Method;
-	jmethodID              m_MethodID;
-	JPTypeName             m_ReturnType;
-	vector<JPTypeName>     m_Arguments;
-	bool                   m_IsStatic;
-	bool                   m_IsFinal;
-	bool                   m_IsConstructor;
+	JPClass*                 m_Class;
+	jobject                  m_Method;
+	jmethodID                m_MethodID;
+	JPTypeName               m_ReturnType;
+	vector<JPTypeName>       m_Arguments;
+	bool                     m_IsStatic;
+	bool                     m_IsFinal;
+	bool                     m_IsConstructor;
+	mutable vector<JPType*>  m_ArgumentsTypeCache;
+	mutable JPType*          m_ReturnTypeCache;
 };
 
 #endif // _JPMETHODOVERLOAD_H_

--- a/native/common/include/jp_objecttypes.h
+++ b/native/common/include/jp_objecttypes.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
-   Copyright 2004 Steve Ménard
+   Copyright 2004 Steve MÃ©nard
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -72,9 +72,10 @@ public :
 	}
 
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
+	virtual bool isSubTypeOf(const JPType& other) const;
 
 protected :
-	virtual jclass    getClass() = 0;	
+	virtual jclass    getClass() const = 0;
 	
 private :
 	JPTypeName m_Type;
@@ -93,7 +94,7 @@ public :
 	}
 
 protected :
-	virtual jclass    getClass();	
+	virtual jclass    getClass() const;
 
 public : // JPType implementation	
 	virtual HostRef*  asHostObject(jvalue val);
@@ -113,7 +114,7 @@ public :
 	}
 
 protected :
-	virtual jclass    getClass();	
+	virtual jclass    getClass() const;
 
 public : // JPType implementation
 	virtual HostRef*  asHostObject(jvalue val);

--- a/native/common/include/jp_primitivetypes.h
+++ b/native/common/include/jp_primitivetypes.h
@@ -97,6 +97,10 @@ public : // JPType implementation
 	}
 
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
+	virtual bool isSubTypeOf(const JPType& other) const
+	{
+		return other.getName().getType() == JPTypeName::_void;
+	}
 };
 
 class JPByteType : public JPPrimitiveType
@@ -134,6 +138,18 @@ public : // JPType implementation
 
 
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
+
+	virtual bool isSubTypeOf(const JPType& other) const
+	{
+		JPTypeName::ETypes otherType = other.getName().getType();
+		return otherType == JPTypeName::_byte
+				|| otherType == JPTypeName::_short
+				|| otherType == JPTypeName::_int
+				|| otherType == JPTypeName::_long
+				|| otherType == JPTypeName::_float
+				|| otherType == JPTypeName::_double;
+	}
+
 };
 
 class JPShortType : public JPPrimitiveType
@@ -169,6 +185,16 @@ public : // JPType implementation
 	virtual PyObject* getArrayRangeToSequence(jarray, int start, int length);
 
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
+	virtual bool isSubTypeOf(const JPType& other) const
+	{
+		JPTypeName::ETypes otherType = other.getName().getType();
+		return otherType == JPTypeName::_short
+				|| otherType == JPTypeName::_int
+				|| otherType == JPTypeName::_long
+				|| otherType == JPTypeName::_float
+				|| otherType == JPTypeName::_double;
+	}
+
 };
 
 class JPIntType : public JPPrimitiveType
@@ -204,7 +230,15 @@ public : // JPType implementation
 	virtual PyObject* getArrayRangeToSequence(jarray, int start, int length);
 
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
-	
+
+	virtual bool isSubTypeOf(const JPType& other) const
+	{
+		JPTypeName::ETypes otherType = other.getName().getType();
+		return otherType == JPTypeName::_int
+				|| otherType == JPTypeName::_long
+				|| otherType == JPTypeName::_float
+				|| otherType == JPTypeName::_double;
+	}
 };
 
 class JPLongType : public JPPrimitiveType
@@ -240,6 +274,13 @@ public : // JPType implementation
 	virtual PyObject* getArrayRangeToSequence(jarray, int start, int length);
 
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
+	virtual bool isSubTypeOf(const JPType& other) const
+	{
+		JPTypeName::ETypes otherType = other.getName().getType();
+		return otherType == JPTypeName::_long
+				|| otherType == JPTypeName::_float
+				|| otherType == JPTypeName::_double;
+	}
 };
 
 class JPFloatType : public JPPrimitiveType
@@ -275,6 +316,12 @@ public : // JPType implementation
 	virtual PyObject* getArrayRangeToSequence(jarray, int start, int length);
 	
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
+	virtual bool isSubTypeOf(const JPType& other) const
+	{
+		JPTypeName::ETypes otherType = other.getName().getType();
+		return otherType == JPTypeName::_float
+				|| otherType == JPTypeName::_double;
+	}
 };
 
 class JPDoubleType : public JPPrimitiveType
@@ -310,6 +357,13 @@ public : // JPType implementation
 	virtual PyObject* getArrayRangeToSequence(jarray, int start, int length);
 	
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
+
+	virtual bool isSubTypeOf(const JPType& other) const
+	{
+		JPTypeName::ETypes otherType = other.getName().getType();
+		return otherType == JPTypeName::_double;
+	}
+
 };
 
 class JPCharType : public JPPrimitiveType
@@ -345,6 +399,16 @@ public : // JPType implementation
 	virtual PyObject* getArrayRangeToSequence(jarray, int start, int length);
 	
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
+	virtual bool isSubTypeOf(const JPType& other) const
+	{
+		JPTypeName::ETypes otherType = other.getName().getType();
+		return otherType == JPTypeName::_char
+				|| otherType == JPTypeName::_int
+				|| otherType == JPTypeName::_long
+				|| otherType == JPTypeName::_float
+				|| otherType == JPTypeName::_double;
+	}
+
 };
 
 class JPBooleanType : public JPPrimitiveType
@@ -380,6 +444,11 @@ public : // JPType implementation
 	virtual PyObject* getArrayRangeToSequence(jarray, int start, int length);
 	
 	virtual HostRef*   convertToDirectBuffer(HostRef* src);
+	virtual bool isSubTypeOf(const JPType& other) const
+	{
+		JPTypeName::ETypes otherType = other.getName().getType();
+		return otherType == JPTypeName::_boolean;
+	}
 };
 
 #endif // _JPPRIMITIVETYPE_H_

--- a/native/common/include/jp_type.h
+++ b/native/common/include/jp_type.h
@@ -75,6 +75,10 @@ public :
 
 	virtual HostRef*   convertToDirectBuffer(HostRef* src) = 0;
 
+	// in the sense of
+	// http://docs.oracle.com/javase/specs/jls/se7/html/jls-4.html#jls-4.10
+	virtual bool isSubTypeOf(const JPType& other) const = 0;
+
 	virtual ~JPType()
 	{
 	}

--- a/native/common/include/jp_utility.h
+++ b/native/common/include/jp_utility.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
-   Copyright 2004 Steve Ménard
+   Copyright 2004 Steve MÃ©nard
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -20,6 +20,7 @@
 // Define this to generate the trace calls
 
 // Define this to make the trace calls do their output. If you change this only the core.cpp needs to be recompiled
+//#define TRACING
 #ifdef TRACING
 #define JPYPE_TRACING_INTERNAL
 #endif

--- a/native/common/jp_array.cpp
+++ b/native/common/jp_array.cpp
@@ -51,6 +51,7 @@ PyObject* JPArray::getSequenceFromRange(int start, int stop)
 //	TRACE2("Component type", compType->getName().getSimpleName());
 
 	return compType->getArrayRangeToSequence(m_Object, start, stop);
+//  TRACE_OUT
 }
 
 void JPArray::setRange(int start, int stop, vector<HostRef*>& val)

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -64,7 +64,7 @@ EMatchType JPArrayClass::canConvertToJava(HostRef* o)
 		// Strings are also char[]
 		return _implicit;
 	}
-	else if (JPEnv::getHost()->isSequence(o))
+	else if (JPEnv::getHost()->isSequence(o) && !JPEnv::getHost()->isObject(o))
 	{
 		EMatchType match = _implicit;
 		int length = JPEnv::getHost()->getSequenceLength(o);

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -12,11 +12,11 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
-*****************************************************************************/   
+
+*****************************************************************************/
 #include <jpype.h>
 
-JPClass::JPClass(const JPTypeName& n, jclass c) : 
+JPClass::JPClass(const JPTypeName& n, jclass c) :
 	JPClassBase(n, c),
 	m_SuperClass(NULL),
 	m_Constructors(NULL)
@@ -47,7 +47,7 @@ JPClass::~JPClass()
 
 }
 
-void JPClass::postLoad() 
+void JPClass::postLoad()
 {
 	// Is this an interface?
 	m_IsInterface = JPJni::isInterface(m_Class);
@@ -59,8 +59,8 @@ void JPClass::postLoad()
 	loadConstructors();
 }
 
-void JPClass::loadSuperClass() 
-{	
+void JPClass::loadSuperClass()
+{
 	JPCleaner cleaner;
 
 	// base class .. if any
@@ -69,16 +69,16 @@ void JPClass::loadSuperClass()
 		jclass baseClass = JPEnv::getJava()->GetSuperclass(m_Class);
 		cleaner.addLocal(baseClass);
 
-		if (baseClass != NULL) 
+		if (baseClass != NULL)
 		{
-			JPTypeName baseClassName = JPJni::getName(baseClass);		
+			JPTypeName baseClassName = JPJni::getName(baseClass);
 			m_SuperClass = JPTypeManager::findClass(baseClassName);
 		}
 	}
 }
-	
-void JPClass::loadSuperInterfaces() 
-{	
+
+void JPClass::loadSuperInterfaces()
+{
 	JPCleaner cleaner;
 	// Super interfaces
 	vector<jclass> intf = JPJni::getInterfaces(m_Class);
@@ -92,9 +92,9 @@ void JPClass::loadSuperInterfaces()
 		m_SuperInterfaces.push_back(interface);
 	}
 }
-	
-void JPClass::loadFields() 
-{	
+
+void JPClass::loadFields()
+{
 	JPCleaner cleaner;
 	// fields
 	vector<jobject> fields = JPJni::getDeclaredFields(m_Class);
@@ -105,66 +105,44 @@ void JPClass::loadFields()
 		JPField* field = new JPField(this, *it);
 		if (field->isStatic())
 		{
-			m_StaticFields[field->getName()] = field;  
+			m_StaticFields[field->getName()] = field;
 		}
 		else
 		{
-			m_InstanceFields[field->getName()] = field;  
-		}			
-	}	
+			m_InstanceFields[field->getName()] = field;
+		}
+	}
 }
-	
-void JPClass::loadMethods() 
-{	
+
+void JPClass::loadMethods()
+{
 	JPCleaner cleaner;
 	JPCleaner pcleaner;
 
-	JPClass* superclass;
-
 	// methods
-	vector<jobject> methods = JPJni::getDeclaredMethods(m_Class);
+	vector<jobject> methods = JPJni::getMethods(m_Class);
 	cleaner.addAllLocal(methods);
 
 	for (vector<jobject>::iterator it = methods.begin(); it != methods.end(); it++)
 	{
 		const string& name = JPJni::getMemberName(*it);
-
-		if (JPJni::isMemberPublic(*it) && !JPJni::isMemberAbstract(*it) )
+		JPMethod* method = getMethod(name);
+		if (method == NULL)
 		{
-			JPMethod* method = getMethod(name);
-			if (method == NULL)
-			{
-				method = new JPMethod(m_Class, name, false);
-				m_Methods[name] = method; 
-			}
-			
-			method->addOverload(this, *it);			
+			method = new JPMethod(m_Class, name, false);
+			m_Methods[name] = method;
 		}
+
+		method->addOverload(this, *it);
 	}
 
-    superclass = m_SuperClass;
-
-	// add previous overloads to methods defined in THIS class
-	while (superclass != NULL)
-	{
-		for (map<string, JPMethod*>::iterator cur = m_Methods.begin(); cur != m_Methods.end(); cur ++)
-		{
-			const string& name = cur->first;
-			JPMethod* superMethod = superclass->getMethod(name);
-			if (superMethod != NULL)
-			{
-				cur->second->addOverloads(superMethod);
-			}
-		}
-        superclass = superclass->getSuperClass();
-	}		
 }
 
-void JPClass::loadConstructors() 
+void JPClass::loadConstructors()
 {
 	JPCleaner cleaner;
 
-	m_Constructors = new JPMethod(m_Class, "[init", true); 
+	m_Constructors = new JPMethod(m_Class, "[init", true);
 
 	if (JPJni::isAbstract(m_Class))
 	{
@@ -172,7 +150,7 @@ void JPClass::loadConstructors()
 		return;
 	}
 
-	
+
 	vector<jobject> methods = JPJni::getDeclaredConstructors(m_Class);
 	cleaner.addAllLocal(methods);
 
@@ -213,25 +191,25 @@ JPMethod* JPClass::getMethod(const string& name)
 	{
 		return NULL;
 	}
-	
+
 	return it->second;
 }
 
 HostRef* JPClass::getStaticAttribute(const string& name)
 {
-	// static fields 
+	// static fields
 	map<string, JPField*>::iterator fld = m_StaticFields.find(name);
 	if (fld != m_StaticFields.end())
 	{
 		return fld->second->getStaticAttribute();
 	}
-		
+
 	JPEnv::getHost()->setAttributeError(name.c_str());
 	JPEnv::getHost()->raise("getAttribute");
 	return NULL; // never reached
 }
 
-HostRef* JPClass::asHostObject(jvalue obj) 
+HostRef* JPClass::asHostObject(jvalue obj)
 {
 	TRACE_IN("JPClass::asPyObject");
 	if (obj.l == NULL)
@@ -245,7 +223,7 @@ HostRef* JPClass::asHostObject(jvalue obj)
 		JPType* arrayType = JPTypeManager::getType(name);
 		return arrayType->asHostObject(obj);
 	}
-	
+
 	return JPEnv::getHost()->newObject(new JPObject(name, obj.l));
 	TRACE_OUT;
 }
@@ -260,7 +238,7 @@ EMatchType JPClass::canConvertToJava(HostRef* obj)
 	JPCleaner cleaner;
 
 	const string& simpleName = m_Name.getSimpleName();
-	
+
 	if (simpleName == "java.lang.Byte" || simpleName == "java.lang.Short" ||
 	    simpleName == "java.lang.Integer")
 	{
@@ -268,21 +246,21 @@ EMatchType JPClass::canConvertToJava(HostRef* obj)
 		{
 			return _explicit;
 		}
-	}    	
-	
+	}
+
 	if (simpleName == "java.lang.Long" && JPEnv::getHost()->isLong(obj))
 	{
 		return _explicit;
 	}
-	
+
 	if (simpleName == "java.lang.Float" || simpleName == "java.lang.Double")
 	{
 		if (JPEnv::getHost()->isFloat(obj))
 		{
 			return _explicit;
 		}
-	}    	
-		
+	}
+
 	if (JPEnv::getHost()->isObject(obj))
 	{
 		JPObject* o = JPEnv::getHost()->asObject(obj);
@@ -332,13 +310,13 @@ EMatchType JPClass::canConvertToJava(HostRef* obj)
 		{
 			return _implicit;
 		}
-		
+
 		// Strings are objects too
 		if (JPEnv::getHost()->isString(obj))
 		{
 			return _implicit;
 		}
-		
+
 		// Class are objects too
 		if (JPEnv::getHost()->isClass(obj) || JPEnv::getHost()->isArrayClass(obj))
 		{
@@ -350,12 +328,12 @@ EMatchType JPClass::canConvertToJava(HostRef* obj)
 		{
 			return _implicit;
 		}
-		
+
 		if (JPEnv::getHost()->isLong(obj))
 		{
 			return _implicit;
 		}
-		
+
 		if (JPEnv::getHost()->isFloat(obj))
 		{
 			return _implicit;
@@ -373,9 +351,9 @@ EMatchType JPClass::canConvertToJava(HostRef* obj)
 jvalue JPClass::buildObjectWrapper(HostRef* obj)
 {
 	jvalue res;
-	
+
 	JPCleaner cleaner;
-	
+
 	vector<HostRef*> args(1);
 	args.push_back(obj);
 
@@ -405,20 +383,20 @@ jvalue JPClass::convertToJava(HostRef* obj)
 	    simpleName == "java.lang.Integer"))
 	{
 		return buildObjectWrapper(obj);
-	}    	
-	
+	}
+
 	if ((JPEnv::getHost()->isInt(obj) || JPEnv::getHost()->isLong(obj)) && simpleName == "java.lang.Long" && JPEnv::getHost()->isLong(obj))
 	{
 		return buildObjectWrapper(obj);
 	}
-	
+
 	if (JPEnv::getHost()->isFloat(obj) && (simpleName == "java.lang.Float" || simpleName == "java.lang.Double"))
 	{
 		if (JPEnv::getHost()->isFloat(obj))
 		{
 			return buildObjectWrapper(obj);
 		}
-	}    	
+	}
 
 	if (JPEnv::getHost()->isString(obj))
 	{
@@ -450,14 +428,14 @@ jvalue JPClass::convertToJava(HostRef* obj)
 		JPType* t = JPTypeManager::getType(tname);
 		res.l = t->convertToJavaObject(obj);
 	}
-	
+
 	if (JPEnv::getHost()->isLong(obj))
 	{
 		JPTypeName tname = JPTypeName::fromType(JPTypeName::_long);
 		JPType* t = JPTypeManager::getType(tname);
 		res.l = t->convertToJavaObject(obj);
 	}
-	
+
 	if (JPEnv::getHost()->isFloat(obj))
 	{
 		JPTypeName tname = JPTypeName::fromType(JPTypeName::_double);
@@ -475,7 +453,7 @@ jvalue JPClass::convertToJava(HostRef* obj)
 	if (JPEnv::getHost()->isArray(obj) && simpleName == "java.lang.Object")
 	{
 		JPArray* a = JPEnv::getHost()->asArray(obj);
-		res = a->getValue();		
+		res = a->getValue();
 	}
 
 	return res;
@@ -494,7 +472,7 @@ void JPClass::setStaticAttribute(const string& name, HostRef* val)
 		JPEnv::getHost()->setAttributeError(name.c_str());
 		JPEnv::getHost()->raise("__setattr__");
 	}
-		
+
 	it->second->setStaticAttribute(val);
 }
 

--- a/native/common/jp_objecttypes.cpp
+++ b/native/common/jp_objecttypes.cpp
@@ -215,6 +215,25 @@ HostRef* JPObjectType::convertToDirectBuffer(HostRef* src)
 	RAISE(JPypeException, "Unable to convert to Direct Buffer");
 }
 
+bool JPObjectType::isSubTypeOf(const JPType& other) const
+{
+	const JPObjectType* otherObjectType = dynamic_cast<const JPObjectType*>(&other);
+	if (!otherObjectType)
+	{
+		return false;
+	}
+	JPCleaner cleaner;
+	jclass ourClass = getClass();
+	cleaner.addLocal(ourClass);
+	jclass otherClass = otherObjectType->getClass();
+	cleaner.addLocal(otherClass);
+	// IsAssignableFrom is a jni method and the order of parameters is counterintuitive
+	bool otherIsSuperType = JPEnv::getJava()->IsAssignableFrom(ourClass, otherClass);
+	//std::cout << other.getName().getSimpleName() << " isSuperType of " << getName().getSimpleName() << " " << otherIsSuperType << std::endl;
+	return otherIsSuperType;
+}
+
+
 //-------------------------------------------------------------------------------
 
 HostRef* JPStringType::asHostObject(jvalue val) 
@@ -336,7 +355,7 @@ jvalue JPStringType::convertToJava(HostRef* obj)
 	TRACE_OUT;
 }
 
-jclass JPStringType::getClass()
+jclass JPStringType::getClass() const
 {
 	return (jclass)JPEnv::getJava()->NewGlobalRef(JPJni::s_StringClass);
 }
@@ -409,7 +428,7 @@ jvalue JPClassType::convertToJava(HostRef* obj)
 	return v;		
 }
 
-jclass JPClassType::getClass()
+jclass JPClassType::getClass() const
 {
 	return (jclass)JPEnv::getJava()->NewGlobalRef(JPJni::s_ClassClass);
 }

--- a/native/python/include/py_class.h
+++ b/native/python/include/py_class.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
-   Copyright 2004 Steve Ménard
+   Copyright 2004 Steve MÃ©nard
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ struct PyJPClass
 	static PyObject* isSubclass(PyObject* self, PyObject* arg);
 	static PyObject* isException(PyObject* self, PyObject* arg);
 	static PyObject* isArray(PyObject* self, PyObject* arg);
+	static PyObject* isAbstract(PyObject* self, PyObject* arg);
 
 	static PyObject* getConstructors(PyObject* self);
 	static PyObject* getDeclaredConstructors(PyObject* self);

--- a/native/python/jpype_javaarray.cpp
+++ b/native/python/jpype_javaarray.cpp
@@ -163,7 +163,7 @@ PyObject* JPypeJavaArray::getArraySlice(PyObject* self, PyObject* arg)
 
 PyObject* JPypeJavaArray::setArraySlice(PyObject* self, PyObject* arg)
 {
-
+	TRACE_IN("JPypeJavaArray::setArraySlice")
 	PyObject* arrayObject;
 	int lo = -1;
 	int hi = -1;
@@ -213,6 +213,7 @@ PyObject* JPypeJavaArray::setArraySlice(PyObject* self, PyObject* arg)
 	PY_STANDARD_CATCH
 
 	return NULL;
+	TRACE_OUT
 }
 
 PyObject* JPypeJavaArray::setArrayItem(PyObject* self, PyObject* arg)

--- a/native/python/py_class.cpp
+++ b/native/python/py_class.cpp
@@ -18,19 +18,20 @@
 #include <jpype_python.h>  
 
 static PyMethodDef classMethods[] = {
-  {"getName",              &PyJPClass::getName, METH_VARARGS, ""},
-  {"getBaseClass",         &PyJPClass::getBaseClass, METH_VARARGS, ""},
-  {"getClassFields",       &PyJPClass::getClassFields, METH_VARARGS, ""},
-  {"getClassMethods",      &PyJPClass::getClassMethods, METH_VARARGS, ""},
+  {"getName",              &PyJPClass::getName, METH_NOARGS, ""},
+  {"getBaseClass",         &PyJPClass::getBaseClass, METH_NOARGS, ""},
+  {"getClassFields",       &PyJPClass::getClassFields, METH_NOARGS, ""},
+  {"getClassMethods",      &PyJPClass::getClassMethods, METH_NOARGS, ""},
   {"newClassInstance",     &PyJPClass::newClassInstance, METH_VARARGS, ""},
 
-  {"isInterface", &PyJPClass::isInterface, METH_VARARGS, ""},
-  {"getBaseInterfaces", &PyJPClass::getBaseInterfaces, METH_VARARGS, ""},
+  {"isInterface", &PyJPClass::isInterface, METH_NOARGS, ""},
+  {"getBaseInterfaces", &PyJPClass::getBaseInterfaces, METH_NOARGS, ""},
   {"isSubclass", &PyJPClass::isSubclass, METH_VARARGS, ""},
-  {"isPrimitive", &PyJPClass::isPrimitive, METH_VARARGS, ""},
+  {"isPrimitive", &PyJPClass::isPrimitive, METH_NOARGS, ""},
 
-  {"isException", &PyJPClass::isException, METH_VARARGS, ""},
-  {"isArray", &PyJPClass::isArray, METH_VARARGS, ""},
+  {"isException", &PyJPClass::isException, METH_NOARGS, ""},
+  {"isArray", &PyJPClass::isArray, METH_NOARGS, ""},
+  {"isAbstract", &PyJPClass::isAbstract, METH_NOARGS, ""},
   {"getSuperclass",&PyJPClass::getBaseClass, METH_NOARGS, ""},
 
   {"getConstructors", (PyCFunction)&PyJPClass::getConstructors, METH_NOARGS, ""},
@@ -535,4 +536,19 @@ PyObject* PyJPClass::isArray(PyObject* o, PyObject* args)
 	PY_STANDARD_CATCH;
 	return NULL;
 	
+}
+PyObject* PyJPClass::isAbstract(PyObject* o, PyObject* args)
+{
+	try {
+		JPCleaner cleaner;
+		PyJPClass* self = (PyJPClass*)o;
+		if (self->m_Class->isAbstract()) {
+			return JPyBoolean::getTrue();
+		} else {
+			return JPyBoolean::getFalse();
+		}
+	}
+	PY_STANDARD_CATCH;
+	return NULL;
+
 }

--- a/test/harness/jpype/attr/SyntheticMethods.java
+++ b/test/harness/jpype/attr/SyntheticMethods.java
@@ -1,0 +1,17 @@
+package jpype.attr;
+
+import java.util.List;
+
+public class SyntheticMethods {
+    public static interface GenericInterface<T> {
+        void foo(T value);
+    }
+
+    public static class GenericImpl implements GenericInterface<List> {
+        public List mListValue = null;
+        public void foo(List value) {
+            mListValue = value;
+        }
+    }
+
+}

--- a/test/harness/jpype/collection/TestEnum.java
+++ b/test/harness/jpype/collection/TestEnum.java
@@ -1,0 +1,5 @@
+package jpype.collection;
+
+enum TestEnum {
+A,B
+}

--- a/test/harness/jpype/overloads/Test1.java
+++ b/test/harness/jpype/overloads/Test1.java
@@ -1,0 +1,204 @@
+package jpype.overloads;
+
+import java.util.List;
+
+public class Test1 {
+    public static class A{}
+    public static class B extends A {}
+    public static class C extends B {}
+    
+    public String testMostSpecific(A a) {
+    return "A";
+    }
+    public String testMostSpecific(B b) {
+    return "B";
+    }
+    
+    public String testVarArgs(A a, A... as) {
+    return "A,A...";
+    }
+    public String testVarArgs(A a, B... bs) {
+    return "A,B...";
+    }
+    public String testVarArgs(B a, B... bs) {
+    return "B,B...";
+    }
+    
+    public String testPrimitive(byte v) {
+    return "byte";
+    }
+    public String testPrimitive(Byte v) {
+    return "Byte";
+    }
+    public String testPrimitive(short v) {
+    return "short";
+    }
+    public String testPrimitive(Short v) {
+    return "Short";
+    }
+    public String testPrimitive(int v) {
+    return "int";
+    }
+    public String testPrimitive(Integer v) {
+    return "Integer";
+    }
+    public String testPrimitive(long v) {
+    return "long";
+    }
+    public String testPrimitive(Long v) {
+    return "Long";
+    }
+    public String testPrimitive(float v) {
+    return "float";
+    }
+    public String testPrimitive(Float v) {
+    return "Float";
+    }
+    public String testPrimitive(double v) {
+    return "double";
+    }
+    public String testPrimitive(Double v) {
+    return "Double";
+    }
+    public String testPrimitive(boolean v) {
+    return "boolean";
+    }
+    public String testPrimitive(Boolean v) {
+    return "Boolean";
+    }
+    public String testPrimitive(char v) {
+    return "char";
+    }
+    public String testPrimitive(Character v) {
+    return "Character";
+    }
+    
+    public static String testInstanceVsClass(B b) { return "static B";}
+    public String testInstanceVsClass(A a) { return "instance A"; }
+    public static String testJavaInstanceVsClass() {
+    return new Test1().testInstanceVsClass(new C());
+    }
+
+    /*
+                      I1
+                    /   \
+                   I2    I3
+                    \   /  \
+                      I4   I5
+                      |  \  |
+                      I6   I7
+                         \  |
+                           I8
+    */
+    
+    public static interface I1 {}
+    public static interface I2 extends I1 {}
+    public static interface I3 extends I1 {}
+    public static interface I4 extends I2, I3 {}
+    public static interface I5 extends I3 {}
+    public static interface I6 extends I4 {}
+    public static interface I7 extends I4,I5 {}
+    public static interface I8 extends I6,I7 {}
+
+    public static class I1Impl implements I1 {}
+    public static class I2Impl implements I2 {}
+    public static class I3Impl implements I3 {}
+    public static class I4Impl implements I4 {}
+    public static class I5Impl implements I5 {}
+    public static class I6Impl implements I6 {}
+    public static class I7Impl implements I7 {}
+    public static class I8Impl implements I8 {}
+
+    public String testInterfaces1(I2 v) {
+    return "I2";
+    }
+    public String testInterfaces1(I3 v) {
+    return "I3";
+    }
+
+    public String testInterfaces2(I2 v) {
+        return "I2";
+    }
+    public String testInterfaces2(I3 v) {
+        return "I3";
+    }
+    public String testInterfaces2(I4 v) {
+        return "I4";
+    }
+
+    public String testInterfaces3(I4 v) {
+        return "I4";
+    }
+    public String testInterfaces3(I5 v) {
+        return "I5";
+    }
+
+    public String testInterfaces4(I1 v) {
+        return "I1";
+    }
+    public String testInterfaces4(I2 v) {
+        return "I2";
+    }
+    public String testInterfaces4(I3 v) {
+        return "I3";
+    }
+    public String testInterfaces4(I4 v) {
+        return "I4";
+    }
+    public String testInterfaces4(I5 v) {
+        return "I5";
+    }
+    public String testInterfaces4(I6 v) {
+        return "I6";
+    }
+    public String testInterfaces4(I7 v) {
+        return "I7";
+    }
+    public String testInterfaces4(I8 v) {
+        return "I8";
+    }
+    
+    
+    public String testClassVsObject(Object v) {
+        return "Object";
+    }
+    public String testClassVsObject(Class v) {
+        return "Class";
+    }
+
+    public String testStringArray(Object v) {
+        return "Object";
+    }
+    public String testStringArray(String v) {
+        return "String";
+    }
+    public String testStringArray(String[] v) {
+        return "String[]";
+    }
+    
+    
+    public String testListVSArray(String[] v) {
+        return "String[]";
+    }
+    public String testListVSArray(List<String> v) {
+        return "List<String>";
+    }
+    
+    /* tests for java 1.8 default methods, commented out for travis environment
+    public interface IDefaultA {
+        public default String defaultMethod() {
+            return "A";
+        }
+    }
+    public interface IDefaultB extends IDefaultA {
+        public default String defaultMethod() {
+            return "B";
+        }
+    }
+    public interface IDefaultC extends IDefaultA, IDefaultB {
+    }
+    public static class DefaultC implements IDefaultC {
+    }
+    //*/
+    
+}

--- a/test/jpypetest/array.py
+++ b/test/jpypetest/array.py
@@ -26,6 +26,7 @@ from . import common
 if sys.version > '3':
     unicode = str
 
+
 def haveNumpy():
     try:
         import numpy
@@ -33,14 +34,15 @@ def haveNumpy():
     except ImportError:
         return False
 
-class ArrayTestCase(common.JPypeTestCase) :
+
+class ArrayTestCase(common.JPypeTestCase):
 
     def setUp(self):
         common.JPypeTestCase.setUp(self)
-        self.VALUES = [12234,1234,234,1324,424,234,234,142,5,251,242,35,235,62,
-                       1235,46,245132,51, 2, 3, 4]
+        self.VALUES = [12234, 1234, 234, 1324, 424, 234, 234, 142, 5, 251, 242, 35, 235, 62,
+                       1235, 46, 245132, 51, 2, 3, 4]
 
-    def testReadArray(self) :
+    def testReadArray(self):
         t = JPackage("jpype").array.TestArray()
         self.assertNotIsInstance(t, JPackage)
 
@@ -49,13 +51,13 @@ class ArrayTestCase(common.JPypeTestCase) :
         self.assertEqual(t.i[0], self.VALUES[0])
         self.assertCountEqual(self.VALUES[1:-2], t.i[1:-2])
 
-    def testStangeBehavior(self) :
+    def testStangeBehavior(self):
         ''' Test for stange crash reported in bug #1089302'''
         Test2 = jpype.JPackage('jpype.array').Test2
         test = Test2()
         test.test(test.getValue())
 
-    def testWriteArray(self) :
+    def testWriteArray(self):
         t = JPackage("jpype").array.TestArray()
         self.assertNotIsInstance(t, JPackage)
 
@@ -66,14 +68,14 @@ class ArrayTestCase(common.JPypeTestCase) :
         self.assertEqual(t.i[1], 33)
         self.assertEqual(t.i[2], 34)
 
-        self.assertCountEqual(t.i[:5], (32, 33, 34 ,1324, 424) )
+        self.assertCountEqual(t.i[:5], (32, 33, 34, 1324, 424))
 
-    def testObjectArraySimple(self) :
+    def testObjectArraySimple(self):
         a = JArray(java.lang.String, 1)(2)
         a[1] = "Foo"
         self.assertEqual("Foo", a[1])
 
-    def testByteArraySimple(self) :
+    def testByteArraySimple(self):
         a = JArray(JByte)(2)
         a[1] = 2
         self.assertEqual(a[1], 2)
@@ -82,26 +84,26 @@ class ArrayTestCase(common.JPypeTestCase) :
         t = JPackage("jpype").array.TestArray()
         self.assertFalse(isinstance(t, JPackage))
 
-        for i in t.i :
+        for i in t.i:
             self.assertNotEqual(i, 0)
 
-    def testGetSubclass(self) :
+    def testGetSubclass(self):
         t = JPackage("jpype").array.TestArray()
         v = t.getSubClassArray()
 
         self.assertTrue(isinstance(v[0], unicode))
 
-    def testGetArrayAsObject(self) :
+    def testGetArrayAsObject(self):
         t = JPackage("jpype").array.TestArray()
         v = t.getArrayAsObject()
 
-    def testCharArrayAsString(self) :
+    def testCharArrayAsString(self):
         t = JPackage("jpype").array.TestArray()
         v = t.charArray
         self.assertEqual(str(v), 'avcd')
         self.assertEqual(unicode(v), u'avcd')
 
-    def testByteArrayAsString(self) :
+    def testByteArrayAsString(self):
         t = JPackage("jpype").array.TestArray()
         v = t.byteArray
         self.assertEqual(str(v), 'avcd')
@@ -128,7 +130,7 @@ class ArrayTestCase(common.JPypeTestCase) :
         self.assertEqual(unicode(v[:]), u'avcd')
 
     def testJArrayConversionByte(self):
-        expected = (0,1,2,3)
+        expected = (0, 1, 2, 3)
         ByteBuffer = jpype.java.nio.ByteBuffer
         bb = ByteBuffer.allocate(4)
         buf = bb.array()
@@ -139,22 +141,22 @@ class ArrayTestCase(common.JPypeTestCase) :
 
     def testJArrayConversionShort(self):
         # filter out values, which can not be converted to jshort
-        self.VALUES = [v for v in self.VALUES if v < (2**16/2 - 1)
-                                             and v > (2**16/2 * -1)]
+        self.VALUES = [v for v in self.VALUES if v < (2**16 / 2 - 1)
+                       and v > (2**16 / 2 * -1)]
         jarr = jpype.JArray(jpype.JShort)(self.VALUES)
-        result = jarr[0 : len(jarr)]
+        result = jarr[0: len(jarr)]
         self.assertCountEqual(self.VALUES, result)
 
         result = jarr[2:10]
         self.assertCountEqual(self.VALUES[2:10], result)
 
         # TODO: investigate why overflow is being casted on linux, but not on windows
-        #with self.assertRaises(jpype._):
+        # with self.assertRaises(jpype._):
         #    jpype.JArray(jpype.JShort)([2**16/2])
 
     def testJArrayConversionInt(self):
         jarr = jpype.JArray(jpype.JInt)(self.VALUES)
-        result = jarr[0 : len(jarr)]
+        result = jarr[0: len(jarr)]
         self.assertCountEqual(self.VALUES, result)
 
         result = jarr[2:10]
@@ -162,7 +164,7 @@ class ArrayTestCase(common.JPypeTestCase) :
 
     def testJArrayConversionLong(self):
         jarr = jpype.JArray(jpype.JLong)(self.VALUES)
-        result = jarr[0 : len(jarr)]
+        result = jarr[0: len(jarr)]
         self.assertCountEqual(self.VALUES, result)
 
         result = jarr[2:10]
@@ -171,7 +173,7 @@ class ArrayTestCase(common.JPypeTestCase) :
     def testJArrayConversionFloat(self):
         VALUES = [float(x) for x in self.VALUES]
         jarr = jpype.JArray(jpype.JFloat)(VALUES)
-        result = jarr[0 : len(jarr)]
+        result = jarr[0: len(jarr)]
         self.assertCountEqual(jarr, result)
 
         result = jarr[2:10]
@@ -259,7 +261,8 @@ class ArrayTestCase(common.JPypeTestCase) :
     def testSetFromNPLongArray(self):
         import numpy as np
         n = 100
-        # actuall the lower bound should be -2**63 -1, but raises Overflow error in numpy
+        # actuall the lower bound should be -2**63 -1, but raises Overflow
+        # error in numpy
         a = np.random.randint(-2**63, 2**63 - 1, size=n).astype(np.int64)
         jarr = jpype.JArray(jpype.JLong)(n)
         jarr[:] = a

--- a/test/jpypetest/attr.py
+++ b/test/jpypetest/attr.py
@@ -265,3 +265,8 @@ class AttributeTestCase(common.JPypeTestCase):
         for x in range(0, 10 * free // block_size):
             allocate_then_free()
         
+
+    def testSyntheticMethod(self):
+        h = jpype.JClass('jpype.attr.SyntheticMethods$GenericImpl')()
+        h.foo(jpype.java.util.ArrayList())
+        

--- a/test/jpypetest/collection.py
+++ b/test/jpypetest/collection.py
@@ -11,3 +11,22 @@ class CollectionTestCase(common.JPypeTestCase):
         collection.add(1)
         collection.add(2)
         self.assertEqual([1, 2], [i for i in collection])
+
+    def testIterateHashmap(self):
+        collection = jpype.java.util.HashMap()
+        collection.put('A',1)
+        collection.put('B',2)
+        asdict = dict()
+        for x in collection.entrySet():
+            asdict[x.getKey()] = x.getValue().longValue()
+        self.assertEqual({'A':1,'B':2}, asdict)
+                    
+    def testEnumMap(self):
+        enumclass = jpype.JClass('jpype.collection.TestEnum')
+        enummap = jpype.java.util.EnumMap(enumclass)
+        enummap.put(enumclass.A, 'ABC')
+        enummap.put(enumclass.B, 'DEF')
+        asdict = dict()
+        for x in enummap.entrySet():
+            asdict[str(x.getKey())] = x.getValue()
+        self.assertEqual({'A':'ABC','B':'DEF'}, asdict)

--- a/test/jpypetest/numeric.py
+++ b/test/jpypetest/numeric.py
@@ -76,9 +76,10 @@ class NumericTestCase(common.JPypeTestCase):
         jwrapper(float(2**127))
         javawrapper(float(2**127))
         self.assertRaises(TypeError, jwrapper, float(2**128))
+        self.assertRaisesRegexp(RuntimeError, 'No matching overloads found', javawrapper, 5) # no conversion from int?
+
         # this difference might be undesirable, 
         # a double bigger than maxfloat passed to java.lang.Float turns into infinity 
         self.assertEquals(float('inf'), javawrapper(float(2**128)).doubleValue())
         self.assertEquals(float('-inf'), javawrapper(float(-2**128)).doubleValue())
-        
-        
+                

--- a/test/jpypetest/objectwrapper.py
+++ b/test/jpypetest/objectwrapper.py
@@ -22,6 +22,8 @@ except ImportError:
 import jpype
 from jpype import java, JObject, JPackage, JString
 from . import common
+#import os
+#import sys
 
 class ObjectWrapperTestCase(common.JPypeTestCase):
     def testCallOverloads(self):
@@ -46,3 +48,25 @@ class ObjectWrapperTestCase(common.JPypeTestCase):
     def testDefaultTypeNameJavaClass(self):
         o = java.lang.String
         self.assertEqual(JObject(o).typeName, "java.lang.Class")
+
+#     def testMakeSureWeCanLoadAllClasses(self):
+#         def get_system_jars():
+#             for dirpath,_,files in os.walk(jpype.java.lang.System.getProperty("java.home")):
+#                 for file in files:
+#                     if file.endswith('.jar'):
+#                         yield (os.path.join(dirpath,file))
+#         for jar in get_system_jars():
+#             classes = [x.getName() for x in jpype.java.util.jar.JarFile(jar).entries() if x.getName().endswith('.class')]
+#             classes = [x.replace('/','.')[:-6] for x in classes]
+#             for clazz in classes:
+#                 try:
+#                     jpype.JClass(clazz)
+#                 except jpype.JavaException as exception:
+#                     if not 'not found' in exception.message():
+#                         print(clazz)
+#                         print (exception.message())
+#                         #print (exception.stacktrace())
+#                 except:
+#                     print(sys.exc_info()[0])
+#                     pass
+        

--- a/test/jpypetest/overloads.py
+++ b/test/jpypetest/overloads.py
@@ -1,0 +1,164 @@
+#*****************************************************************************
+#   Copyright 2004-2008 Steve Menard
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#*****************************************************************************
+import jpype
+from jpype import JString, java, JArray, JClass, JByte, JShort, JInt, JLong, JFloat, JDouble, JChar, JBoolean
+import sys
+import time
+from . import common
+from jpype._jwrapper import JObject
+
+java = jpype.java
+
+class OverloadTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+        self.__jp = self.jpype.overloads
+        self._aclass = JClass('jpype.overloads.Test1$A')
+        self._bclass = JClass('jpype.overloads.Test1$B')
+        self._cclass = JClass('jpype.overloads.Test1$C')
+        self._a = self._aclass()
+        self._b = self._bclass()
+        self._c = self._cclass()
+        self._i1impl = JClass('jpype.overloads.Test1$I1Impl')()
+        self._i2impl = JClass('jpype.overloads.Test1$I2Impl')()
+        self._i3impl = JClass('jpype.overloads.Test1$I3Impl')()
+        self._i4impl = JClass('jpype.overloads.Test1$I4Impl')()
+        self._i5impl = JClass('jpype.overloads.Test1$I5Impl')()
+        self._i6impl = JClass('jpype.overloads.Test1$I6Impl')()
+        self._i7impl = JClass('jpype.overloads.Test1$I7Impl')()
+        self._i8impl = JClass('jpype.overloads.Test1$I8Impl')()
+        
+    def testMostSpecificInstanceMethod(self):
+        test1 = self.__jp.Test1()
+        self.assertEquals('A', test1.testMostSpecific(self._a))
+        self.assertEquals('B', test1.testMostSpecific(self._b))
+        self.assertEquals('B', test1.testMostSpecific(self._c))
+        self.assertEquals('B', test1.testMostSpecific(None))
+
+    def testForceOverloadResolution(self):
+        test1 = self.__jp.Test1()
+        self.assertEquals('A', test1.testMostSpecific(JObject(self._c, self._aclass)))
+        self.assertEquals('B', test1.testMostSpecific(JObject(self._c, self._bclass)))
+        # JObject wrapper forces exact matches
+        self.assertRaisesRegexp(RuntimeError, 'No matching overloads found', test1.testMostSpecific, JObject(self._c, self._cclass))
+        self.assertEquals('A', test1.testMostSpecific(JObject(self._c, 'jpype.overloads.Test1$A')))
+        self.assertEquals('B', test1.testMostSpecific(JObject(self._c, 'jpype.overloads.Test1$B')))
+        # JObject wrapper forces exact matches
+        self.assertRaisesRegexp(RuntimeError, 'No matching overloads found', test1.testMostSpecific, JObject(self._c, 'jpype.overloads.Test1$C'))
+        
+    def testVarArgsCall(self):
+        test1 = self.__jp.Test1()
+        self.assertEquals('A,B...', test1.testVarArgs(self._a,[]))
+        self.assertEquals('A,B...', test1.testVarArgs(self._a, None))
+        self.assertEquals('A,B...', test1.testVarArgs(self._a, [self._b]))
+        self.assertEquals('A,A...', test1.testVarArgs(self._a, [self._a]))
+        self.assertEquals('A,B...', test1.testVarArgs(self._a, [self._b,self._b]))
+        self.assertEquals('B,B...', test1.testVarArgs(self._b, [self._b,self._b]))
+        self.assertEquals('B,B...', test1.testVarArgs(self._c, [self._c,self._b]))
+        self.assertEquals('B,B...', test1.testVarArgs(self._c, JArray(self._cclass,1)([self._c,self._c])))
+        self.assertEquals('B,B...', test1.testVarArgs(self._c, None))
+        self.assertEquals('B,B...', test1.testVarArgs(None, None))
+        
+    def testPrimitive(self):
+        test1 = self.__jp.Test1()
+        self.assertEquals('long', test1.testPrimitive(5))
+        self.assertEquals('byte', test1.testPrimitive(JByte(5)))
+        self.assertEquals('Byte', test1.testPrimitive(java.lang.Byte(5)))
+        self.assertEquals('short', test1.testPrimitive(JShort(5)))
+        self.assertEquals('Short', test1.testPrimitive(java.lang.Short(5)))
+        self.assertEquals('int', test1.testPrimitive(JInt(5)))
+        self.assertEquals('Integer', test1.testPrimitive(java.lang.Integer(5)))
+        self.assertEquals('long', test1.testPrimitive(JLong(5)))
+        self.assertEquals('Long', test1.testPrimitive(java.lang.Long(5)))
+        self.assertEquals('float', test1.testPrimitive(JFloat(5)))
+        self.assertEquals('Float', test1.testPrimitive(java.lang.Float(5.0)))
+        self.assertEquals('double', test1.testPrimitive(JDouble(5)))
+        self.assertEquals('Double', test1.testPrimitive(java.lang.Double(5.0)))
+        self.assertEquals('boolean', test1.testPrimitive(JBoolean(5)))
+        self.assertEquals('Boolean', test1.testPrimitive(java.lang.Boolean(5)))
+        self.assertEquals('char', test1.testPrimitive(JChar('5')))
+        self.assertEquals('Character', test1.testPrimitive(java.lang.Character('5')))
+
+    def testInstanceVsClassMethod(self):
+        # this behaviour is different than the one in java, so maybe we should change it?
+        test1 = self.__jp.Test1()
+        self.assertEquals('static B', self.__jp.Test1.testInstanceVsClass(self._c))
+        self.assertEquals('instance A', test1.testInstanceVsClass(self._c))
+        # here what would the above resolve to in java
+        self.assertEquals('static B', self.__jp.Test1.testJavaInstanceVsClass())
+
+    def testInterfaces1(self):
+        test1 = self.__jp.Test1()
+        self.assertRaisesRegexp(RuntimeError, 'Ambiguous overloads found', test1.testInterfaces1, self._i4impl)
+        self.assertEquals('I2', test1.testInterfaces1(JObject(self._i4impl, 'jpype.overloads.Test1$I2')))
+        self.assertEquals('I3', test1.testInterfaces1(JObject(self._i4impl, 'jpype.overloads.Test1$I3')))
+
+    def testInterfaces2(self):
+        test1 = self.__jp.Test1()
+        self.assertEquals('I4', test1.testInterfaces2(self._i4impl))
+        self.assertEquals('I2', test1.testInterfaces2(JObject(self._i4impl, 'jpype.overloads.Test1$I2')))
+        self.assertEquals('I3', test1.testInterfaces2(JObject(self._i4impl, 'jpype.overloads.Test1$I3')))
+
+    def testInterfaces3(self):
+        test1 = self.__jp.Test1()
+        self.assertRaisesRegexp(RuntimeError, 'Ambiguous overloads found', test1.testInterfaces3, self._i8impl)
+        self.assertEquals('I4', test1.testInterfaces3(self._i6impl))
+        self.assertRaisesRegexp(RuntimeError, 'No matching overloads found', test1.testInterfaces3, self._i3impl)
+
+    def testInterfaces4(self):
+        test1 = self.__jp.Test1()
+        self.assertEquals('I8', test1.testInterfaces4(None))
+        self.assertEquals('I1', test1.testInterfaces4(self._i1impl))
+        self.assertEquals('I2', test1.testInterfaces4(self._i2impl))
+        self.assertEquals('I3', test1.testInterfaces4(self._i3impl))
+        self.assertEquals('I4', test1.testInterfaces4(self._i4impl))
+        self.assertEquals('I5', test1.testInterfaces4(self._i5impl))
+        self.assertEquals('I6', test1.testInterfaces4(self._i6impl))
+        self.assertEquals('I7', test1.testInterfaces4(self._i7impl))
+        self.assertEquals('I8', test1.testInterfaces4(self._i8impl))
+    
+    def testClassVsObject(self):
+        test1 = self.__jp.Test1()
+        self.assertEquals('Object', test1.testClassVsObject(self._i4impl))
+        self.assertEquals('Object', test1.testClassVsObject(1))
+        self.assertEquals('Class', test1.testClassVsObject(None))
+        self.assertEquals('Class', test1.testClassVsObject(JClass('jpype.overloads.Test1$I4Impl')))
+        self.assertEquals('Class', test1.testClassVsObject(JClass('jpype.overloads.Test1$I3')))
+        
+    def testStringArray(self):
+        test1 = self.__jp.Test1()
+        self.assertEquals('Object', test1.testStringArray(self._i4impl))
+        self.assertEquals('Object', test1.testStringArray(1))
+        self.assertRaisesRegexp(RuntimeError, 'Ambiguous overloads found', test1.testStringArray, None)
+        self.assertEquals('String', test1.testStringArray('somestring'))
+        self.assertEquals('String[]', test1.testStringArray([]))
+        self.assertEquals('String[]', test1.testStringArray(['a','b']))
+        self.assertEquals('String[]', test1.testStringArray(JArray(java.lang.String,1)(['a','b'])))
+        self.assertEquals('Object', test1.testStringArray(JArray(JInt, 1)([1,2])))
+        
+    def testListVSArray(self):
+        test1 = self.__jp.Test1()
+        self.assertEquals('String[]', test1.testListVSArray(['a','b']))
+        self.assertEquals('List<String>', test1.testListVSArray(jpype.java.util.Arrays.asList(['a','b'])))
+        
+    def testDefaultMethods(self):
+        try:
+            testdefault = JClass('jpype.overloads.Test1$DefaultC')()
+        except:
+            pass
+        else:
+            self.assertEquals('B', testdefault.defaultMethod())


### PR DESCRIPTION
using jpype one can always force an overload resolution by using the JObject,JLong,... wrappers. but this is tedious. sometimes an overload is added to a class by the compiler (for example synthetic methods for overriding mixed with generics, see the testcase.) in this PR i tried to implement the rules in http://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.12.2.5 as far as this is possible at runtime. there are quite some tests around this.
also support for default methods in java 1.8 was added by using getMethods instead of a recursive getDeclaredMethods. the test code (in java) is unfortunately commented out as the travis hosts have only java1.7 by default.