### PR TITLE
Fix typedef int8_t problem

### DIFF
--- a/native/jni_include/jni.h
+++ b/native/jni_include/jni.h
@@ -28,7 +28,7 @@
 
 #ifdef _MSC_VER // broken m$ compiler does not have c99 std header
     typedef unsigned char           uint8_t;
-    typedef   signed char           int8_t;
+    typedef signed   char           int8_t;
     typedef short int               int16_t;
     typedef unsigned short int      uint16_t;
     typedef __int32                 int32_t;

--- a/native/jni_include/jni.h
+++ b/native/jni_include/jni.h
@@ -28,7 +28,7 @@
 
 #ifdef _MSC_VER // broken m$ compiler does not have c99 std header
     typedef unsigned char           uint8_t;
-    typedef          char           int8_t;
+    typedef   signed char           int8_t;
     typedef short int               int16_t;
     typedef unsigned short int      uint16_t;
     typedef __int32                 int32_t;


### PR DESCRIPTION
I got an error with MS VC 14.0 compiler (message below) because int8_t typedef was not consistent with stdint.h
It should be 'signed char' instead of 'char'.

Last lines of output of pip install:
```
    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DWIN32=
1 -DHAVE_NUMPY=1 -Inative\common\include -Inative\python\include "-IC:\Program Files\Java\jre1.8.0_65\bin\include" -Inat
ive\jni_include "-Ic:\program files\python35\lib\site-packages\numpy\core\include" "-Ic:\program files\python35\include"
 "-Ic:\program files\python35\include" "-IC:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE" "-IC:\Program
Files (x86)\Microsoft Visual Studio 14.0\VC\ATLMFC\INCLUDE" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.10586
.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\include\um" "-IC:\Program Files (x86)\Windows Kits\10\inc
lude\10.0.10586.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.10586.0\um" "-IC:\Program Files (x86)\W
indows Kits\10\include\10.0.10586.0\winrt" /EHsc /Tpnative\common\jp_array.cpp /Fobuild\temp.win-amd64-3.5\Release\nativ
e\common\jp_array.obj /EHsc
    jp_array.cpp
    native\jni_include\jni.h(31): error C2371: 'int8_t': redefinition; different basic types
    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\stdint.h(17): note: see declaration of 'int8_t'
    error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\BIN\\amd64\\cl.exe' failed with exit stat
us 2

    ----------------------------------------
Command ""c:\program files\python35\python.exe" -u -c "import setuptools, tokenize;__file__='C:\\Users\\z003husp\\AppDat
a\\Local\\Temp\\pip-build-alq9o0x9\\jpype1\\setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().repl
ace('\r\n', '\n'), __file__, 'exec'))" install --record C:\Users\z003husp\AppData\Local\Temp\pip-is_mdcyq-record\install
-record.txt --single-version-externally-managed --compile" failed with error code 1 in C:\Users\z003husp\AppData\Local\T
emp\pip-build-alq9o0x9\jpype1
```