### PR TITLE
fix appveyor tests and bug in jp_primitivetypes_autogen.cpp

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,13 +17,13 @@ environment:
       PYTHON_ARCH: "64"
       JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
 
-    - PYTHON: "C:\\Python34_32"
-      PYTHON_VERSION: "3.4.1"
+    - PYTHON: "C:\\Python3_32"
+      PYTHON_VERSION: "3"
       PYTHON_ARCH: "32"
       JAVA_HOME: "C:\\Program Files (x86)\\Java\\jdk1.8.0"
 
-    - PYTHON: "C:\\Python34_64"
-      PYTHON_VERSION: "3.4.1"
+    - PYTHON: "C:\\Python3_64"
+      PYTHON_VERSION: "3"
       PYTHON_ARCH: "64"
       JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
 

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -96,10 +96,10 @@ function InstallPip ($python_home) {
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -eq "3.4") {
-        $filename = "Miniconda3-3.5.5-Windows-" + $platform_suffix + ".exe"
+    if ($python_version.StartsWith("3")) {
+        $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
     } else {
-        $filename = "Miniconda-3.5.5-Windows-" + $platform_suffix + ".exe"
+        $filename = "Miniconda2-latest-Windows-" + $platform_suffix + ".exe"
     }
     $url = $MINICONDA_URL + $filename
 
@@ -145,15 +145,13 @@ function InstallMiniconda ($python_version, $architecture, $python_home) {
     }
     $filepath = DownloadMiniconda $python_version $platform_suffix
     Write-Host "Installing" $filepath "to" $python_home
-    $install_log = $python_home + ".log"
-    $args = "/S /D=$python_home"
+    $args = "/InstallationType=AllUsers /S /AddToPath=0 /RegisterPython=1 /D=$python_home"
     Write-Host $filepath $args
     Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
     if (Test-Path $python_home) {
         Write-Host "Python $python_version ($architecture) installation complete"
     } else {
         Write-Host "Failed to install Python in $python_home"
-        Get-Content -Path $install_log
         Exit 1
     }
 }

--- a/appveyor/run_with_env.cmd
+++ b/appveyor/run_with_env.cmd
@@ -32,7 +32,11 @@ IF %MAJOR_PYTHON_VERSION% == "2" (
     EXIT 1
 )
 
-IF "%PYTHON_ARCH%"=="64" (
+IF NOT "%PYTHON_ARCH%"=="64" SET NO_SPECIFIC_SDK=1
+IF NOT "%MAJOR_PYTHON_VERSION%" == "2" SET NO_SPECIFIC_SDK=1
+
+
+IF NOT DEFINED NO_SPECIFIC_SDK (
     ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
     SET DISTUTILS_USE_SDK=1
     SET MSSdk=1
@@ -41,7 +45,7 @@ IF "%PYTHON_ARCH%"=="64" (
     ECHO Executing: %COMMAND_TO_RUN%
     call %COMMAND_TO_RUN% || EXIT 1
 ) ELSE (
-    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Using default MSVC build environment on a %PYTHON_ARCH% bit architecture for Python %MAJOR_PYTHON_VERSION%
     ECHO Executing: %COMMAND_TO_RUN%
     call %COMMAND_TO_RUN% || EXIT 1
 )

--- a/native/common/jp_primitivetypes_autogen.cpp
+++ b/native/common/jp_primitivetypes_autogen.cpp
@@ -24,9 +24,9 @@
 typedef unsigned int uint;
 
 #ifdef HAVE_NUMPY
-	#define PY_ARRAY_UNIQUE_SYMBOL jpype_ARRAY_API
-	#define NO_IMPORT_ARRAY
-	#include <numpy/arrayobject.h>
+    #define PY_ARRAY_UNIQUE_SYMBOL jpype_ARRAY_API
+    #define NO_IMPORT_ARRAY
+    #include <numpy/arrayobject.h>
 #else
     #define NPY_BOOL 0
     #define NPY_BYTE 0
@@ -41,10 +41,10 @@ typedef unsigned int uint;
 PyObject* exe = PyErr_Occurred(); \
 if(exe != NULL) \
 {\
-	stringstream ss;\
-	ss <<  "unable to convert element: " << PyUnicode_FromFormat("%R",o) <<\
-			" at index: " << i;\
-	RAISE(JPypeException, ss.str());\
+    stringstream ss;\
+    ss <<  "unable to convert element: " << PyUnicode_FromFormat("%R",o) <<\
+            " at index: " << i;\
+    RAISE(JPypeException, ss.str());\
 }
 
 #if (PY_VERSION_HEX >= 0x02070000)
@@ -54,8 +54,8 @@ if(exe != NULL) \
 template <typename jarraytype, typename jelementtype, typename setFnc>
 inline bool
 setViaBuffer(jarray array, int start, uint length, PyObject* sequence, setFnc setter) {
-	//creates a PyMemoryView from sequence check for typeError,
-	// if no underlying py_buff exists.
+    //creates a PyMemoryView from sequence check for typeError,
+    // if no underlying py_buff exists.
     if(! PyObject_CheckBuffer(sequence)) {
         return false;
     }
@@ -66,14 +66,14 @@ setViaBuffer(jarray array, int start, uint length, PyObject* sequence, setFnc se
 //    PyObject* memview = PyMemoryView_FromObject(sequence);
 
     // check for TypeError, if no underlying py_buff exists.
-	PyObject* err = PyErr_Occurred();
-	if (err) {
-	    PyErr_Clear();
-	    return false;
-	}
+    PyObject* err = PyErr_Occurred();
+    if (err) {
+        PyErr_Clear();
+        return false;
+    }
 
-	// create a memory view
-	Py_buffer* py_buff = PyMemoryView_GET_BUFFER(memview);
+    // create a memory view
+    Py_buffer* py_buff = PyMemoryView_GET_BUFFER(memview);
 
     // ensure length of buffer contains enough elements somehow.
     if ((py_buff->len / sizeof(jelementtype)) != length) {
@@ -253,18 +253,18 @@ void JPByteType::setArrayRange(jarray a, int start, int length, PyObject* sequen
     jbyte* val = NULL;
     jboolean isCopy;
 
-	try {
-		val = JPEnv::getJava()->GetByteArrayElements(array, &isCopy);
-		for (Py_ssize_t i = 0; i < length; ++i) {
-			PyObject* o = PySequence_GetItem(sequence, i);
-			jbyte l = (jbyte) PyInt_AS_LONG(o);
-			Py_DECREF(o);
-			if(l == -1) { CONVERSION_ERROR_HANDLE; }
-			val[start+i] = l;
-		}
-		JPEnv::getJava()->ReleaseByteArrayElements(array, val, 0);
-	}
-	RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseByteArrayElements(array, val, JNI_ABORT); } );
+    try {
+        val = JPEnv::getJava()->GetByteArrayElements(array, &isCopy);
+        for (Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* o = PySequence_GetItem(sequence, i);
+            jbyte l = (jbyte) PyInt_AS_LONG(o);
+            Py_DECREF(o);
+            if(l == -1) { CONVERSION_ERROR_HANDLE; }
+            val[start+i] = l;
+        }
+        JPEnv::getJava()->ReleaseByteArrayElements(array, val, 0);
+    }
+    RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseByteArrayElements(array, val, JNI_ABORT); } );
 }
 
 HostRef* JPByteType::getArrayItem(jarray a, int ndx)
@@ -402,18 +402,18 @@ void JPShortType::setArrayRange(jarray a, int start, int length, PyObject* seque
     jshort* val = NULL;
     jboolean isCopy;
 
-	try {
-		val = JPEnv::getJava()->GetShortArrayElements(array, &isCopy);
-		for (Py_ssize_t i = 0; i < length; ++i) {
-			PyObject* o = PySequence_GetItem(sequence, i);
-			jshort l = (jshort) PyInt_AsLong(o);
-			Py_DECREF(o);
-			if(l == -1) { CONVERSION_ERROR_HANDLE; }
-			val[start+i] = l;
-		}
-		JPEnv::getJava()->ReleaseShortArrayElements(array, val, 0);
-	}
-	RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseShortArrayElements(array, val, JNI_ABORT); } );
+    try {
+        val = JPEnv::getJava()->GetShortArrayElements(array, &isCopy);
+        for (Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* o = PySequence_GetItem(sequence, i);
+            jshort l = (jshort) PyInt_AsLong(o);
+            Py_DECREF(o);
+            if(l == -1) { CONVERSION_ERROR_HANDLE; }
+            val[start+i] = l;
+        }
+        JPEnv::getJava()->ReleaseShortArrayElements(array, val, 0);
+    }
+    RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseShortArrayElements(array, val, JNI_ABORT); } );
 
 }
 
@@ -551,18 +551,18 @@ void JPIntType::setArrayRange(jarray a, int start, int length, PyObject* sequenc
     jint* val = NULL;
     jboolean isCopy;
 
-	try {
-		val = JPEnv::getJava()->GetIntArrayElements(array, &isCopy);
-		for (Py_ssize_t i = 0; i < length; ++i) {
-			PyObject* o = PySequence_GetItem(sequence, i);
-			jint v = (jint) PyInt_AsLong(o);
-			Py_DecRef(o);
-			if (v == -1) { CONVERSION_ERROR_HANDLE }
-			val[start+i] = v;
-		}
+    try {
+        val = JPEnv::getJava()->GetIntArrayElements(array, &isCopy);
+        for (Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* o = PySequence_GetItem(sequence, i);
+            jint v = (jint) PyInt_AsLong(o);
+            Py_DecRef(o);
+            if (v == -1) { CONVERSION_ERROR_HANDLE }
+            val[start+i] = v;
+        }
         JPEnv::getJava()->ReleaseIntArrayElements(array, val, 0);
-	}
-	RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseIntArrayElements(array, val, JNI_ABORT); } );
+    }
+    RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseIntArrayElements(array, val, JNI_ABORT); } );
 }
 
 HostRef* JPIntType::getArrayItem(jarray a, int ndx)
@@ -571,7 +571,7 @@ HostRef* JPIntType::getArrayItem(jarray a, int ndx)
     jint val;
     
     try {
-    	JPEnv::getJava()->GetIntArrayRegion(array, ndx, 1, &val);
+        JPEnv::getJava()->GetIntArrayRegion(array, ndx, 1, &val);
         jvalue v;
         v.i = val;
 
@@ -587,7 +587,7 @@ void JPIntType::setArrayItem(jarray a, int ndx , HostRef* obj)
     
     try {
         val = convertToJava(obj).i;
-    	JPEnv::getJava()->SetIntArrayRegion(array, ndx, 1, &val);
+        JPEnv::getJava()->SetIntArrayRegion(array, ndx, 1, &val);
     }
     RETHROW_CATCH();
 }
@@ -700,18 +700,18 @@ void JPLongType::setArrayRange(jarray a, int start, int length, PyObject* sequen
     jlong* val = NULL;
     jboolean isCopy;
 
-	try {
-		val = JPEnv::getJava()->GetLongArrayElements(array, &isCopy);
-		for (Py_ssize_t i = 0; i < length; ++i) {
-			PyObject* o = PySequence_GetItem(sequence, i);
-			jlong l = (jlong) PyLong_AsLong(o);
-			Py_DECREF(o);
-			if(l == -1) { CONVERSION_ERROR_HANDLE; }
-			val[start+i] = l;
-		}
-		JPEnv::getJava()->ReleaseLongArrayElements(array, val, 0);
-	}
-	RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseLongArrayElements(array, val, JNI_ABORT); } );
+    try {
+        val = JPEnv::getJava()->GetLongArrayElements(array, &isCopy);
+        for (Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* o = PySequence_GetItem(sequence, i);
+            jlong l = (jlong) PyLong_AsLong(o);
+            Py_DECREF(o);
+            if(l == -1) { CONVERSION_ERROR_HANDLE; }
+            val[start+i] = l;
+        }
+        JPEnv::getJava()->ReleaseLongArrayElements(array, val, 0);
+    }
+    RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseLongArrayElements(array, val, JNI_ABORT); } );
 }
 
 
@@ -847,21 +847,21 @@ void JPFloatType::setArrayRange(jarray a, int start, int length, PyObject* seque
             &JPJavaEnv::SetFloatArrayRegion))
         return;
 
-	jfloatArray array = (jfloatArray)a;
-	jfloat* val = NULL;
-	jboolean isCopy;
-	try {
-		val = JPEnv::getJava()->GetFloatArrayElements(array, &isCopy);
-		for (Py_ssize_t i = 0; i < length; ++i) {
-			PyObject* o = PySequence_GetItem(sequence, i);
-			jfloat v = (jfloat) PyFloat_AsDouble(o);
-			Py_DecRef(o);
-			if (v == -1.) { CONVERSION_ERROR_HANDLE; }
-			val[start+i] = v;
-		}
-		JPEnv::getJava()->ReleaseFloatArrayElements(array, val, 0);
-	}
-	RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseFloatArrayElements(array, val, JNI_ABORT); } );
+    jfloatArray array = (jfloatArray)a;
+    jfloat* val = NULL;
+    jboolean isCopy;
+    try {
+        val = JPEnv::getJava()->GetFloatArrayElements(array, &isCopy);
+        for (Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* o = PySequence_GetItem(sequence, i);
+            jfloat v = (jfloat) PyFloat_AsDouble(o);
+            Py_DecRef(o);
+            if (v == -1.) { CONVERSION_ERROR_HANDLE; }
+            val[start+i] = v;
+        }
+        JPEnv::getJava()->ReleaseFloatArrayElements(array, val, 0);
+    }
+    RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseFloatArrayElements(array, val, JNI_ABORT); } );
 }
 
 HostRef* JPFloatType::getArrayItem(jarray a, int ndx)
@@ -993,24 +993,24 @@ void JPDoubleType::setArrayRange(jarray a, int start, int length, PyObject* sequ
 {
     if (setViaBuffer<jdoubleArray, jdouble>(a, start, length, sequence,
             &JPJavaEnv::SetDoubleArrayRegion))
-		return;
+        return;
 
-	jdoubleArray array = (jdoubleArray)a;
-	vector<jdouble> val;
-	val.reserve(length);
-	// fill temporary array
-	for (Py_ssize_t i = 0; i < length; ++i) {
-		PyObject* o = PySequence_GetItem(sequence, i);
-		jdouble d = (jdouble) PyFloat_AsDouble(o);
-		Py_DecRef(o);
-		if (d == -1.) { CONVERSION_ERROR_HANDLE; }
-		val[i] = d;
-	}
+    jdoubleArray array = (jdoubleArray)a;
+    vector<jdouble> val;
+    val.resize(length);
+    // fill temporary array
+    for (Py_ssize_t i = 0; i < length; ++i) {
+        PyObject* o = PySequence_GetItem(sequence, i);
+        jdouble d = (jdouble) PyFloat_AsDouble(o);
+        Py_DecRef(o);
+        if (d == -1.) { CONVERSION_ERROR_HANDLE; }
+        val[i] = d;
+    }
 
-	// set java array
-	try {
-		JPEnv::getJava()->SetDoubleArrayRegion(array, start, length, &val.front());
-	} RETHROW_CATCH();
+    // set java array
+    try {
+        JPEnv::getJava()->SetDoubleArrayRegion(array, start, length, &val.front());
+    } RETHROW_CATCH();
 }
 
 HostRef* JPDoubleType::getArrayItem(jarray a, int ndx)
@@ -1041,7 +1041,7 @@ void JPDoubleType::setArrayItem(jarray a, int ndx , HostRef* obj)
 }
 
 PyObject* JPDoubleType::getArrayRangeToSequence(jarray a, int lo, int hi) {
-	return getSlice<jdouble>(a, lo, hi, NPY_FLOAT64, PyFloat_FromDouble);
+    return getSlice<jdouble>(a, lo, hi, NPY_FLOAT64, PyFloat_FromDouble);
 }
 
 //----------------------------------------------------------
@@ -1144,23 +1144,23 @@ void JPCharType::setArrayRange(jarray a, int start, int length, PyObject* sequen
             &JPJavaEnv::SetCharArrayRegion))
         return;
 
-	jcharArray array = (jcharArray)a;
-	jchar* val = NULL;
-	jboolean isCopy;
-	long c;
+    jcharArray array = (jcharArray)a;
+    jchar* val = NULL;
+    jboolean isCopy;
+    long c;
 
-	try {
-		val = JPEnv::getJava()->GetCharArrayElements(array, &isCopy);
-		for (Py_ssize_t i = 0; i < length; ++i) {
-			PyObject* o = PySequence_GetItem(sequence, i);
-			c = PyInt_AsLong(o);
-			Py_DecRef(o);
-			if(c == -1) { CONVERSION_ERROR_HANDLE; }
-			val[start+i] = (jchar) c;
-		}
-		JPEnv::getJava()->ReleaseCharArrayElements(array, val, 0);
-	}
-	RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseCharArrayElements(array, val, JNI_ABORT); } );
+    try {
+        val = JPEnv::getJava()->GetCharArrayElements(array, &isCopy);
+        for (Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* o = PySequence_GetItem(sequence, i);
+            c = PyInt_AsLong(o);
+            Py_DecRef(o);
+            if(c == -1) { CONVERSION_ERROR_HANDLE; }
+            val[start+i] = (jchar) c;
+        }
+        JPEnv::getJava()->ReleaseCharArrayElements(array, val, 0);
+    }
+    RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseCharArrayElements(array, val, JNI_ABORT); } );
 }
 
 HostRef* JPCharType::getArrayItem(jarray a, int ndx)
@@ -1317,23 +1317,23 @@ void JPBooleanType::setArrayRange(jarray a, int start, int length, PyObject* seq
             &JPJavaEnv::SetBooleanArrayRegion))
         return;
 
-	jbooleanArray array = (jbooleanArray) a;
-	jboolean isCopy;
-	jboolean* val = NULL;
-	long c;
+    jbooleanArray array = (jbooleanArray) a;
+    jboolean isCopy;
+    jboolean* val = NULL;
+    long c;
 
-	try {
-		val = JPEnv::getJava()->GetBooleanArrayElements(array, &isCopy);
-		for (Py_ssize_t i = 0; i < length; ++i) {
-			PyObject* o = PySequence_GetItem(sequence, i);
-			c = PyInt_AsLong(o);
-			Py_DecRef(o);
-			if(c == -1) { CONVERSION_ERROR_HANDLE; }
-			val[start+i] = (jboolean) c;
-		}
-		JPEnv::getJava()->ReleaseBooleanArrayElements(array, val, 0);
-	}
-	RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseBooleanArrayElements(array, val, JNI_ABORT); } );
+    try {
+        val = JPEnv::getJava()->GetBooleanArrayElements(array, &isCopy);
+        for (Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* o = PySequence_GetItem(sequence, i);
+            c = PyInt_AsLong(o);
+            Py_DecRef(o);
+            if(c == -1) { CONVERSION_ERROR_HANDLE; }
+            val[start+i] = (jboolean) c;
+        }
+        JPEnv::getJava()->ReleaseBooleanArrayElements(array, val, 0);
+    }
+    RETHROW_CATCH( if (val != NULL) { JPEnv::getJava()->ReleaseBooleanArrayElements(array, val, JNI_ABORT); } );
 
 }
 

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -202,7 +202,7 @@ void JPProxy::init()
 
 	//Required due to bug in jvm
 	//See: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6493522
-	jmethodID refQConstr = JPEnv::getJava()->GetMethodID(referenceQueue, "<init>", "()V");
+	JPEnv::getJava()->GetMethodID(referenceQueue, "<init>", "()V");
 
 	cleaner.addLocal(reference);
 	cleaner.addLocal(referenceQueue);

--- a/setup.py
+++ b/setup.py
@@ -117,11 +117,10 @@ class my_build_ext(build_ext):
 
     def initialize_options(self, *args):
         """omit -Wstrict-prototypes from CFLAGS since its only valid for C code."""
-        from distutils.sysconfig import get_config_vars
-        (opt,) = get_config_vars('OPT')
-        if opt:
-            os.environ['OPT'] = ' '.join(flag for flag in opt.split()
-                                         if flag != '-Wstrict-prototypes')
+        import distutils.sysconfig
+        cfg_vars = distutils.sysconfig.get_config_vars()
+        if 'CFLAGS' in cfg_vars:
+            cfg_vars['CFLAGS'] = cfg_vars['CFLAGS'].replace('-Wstrict-prototypes', '')
 
         build_ext.initialize_options(self)
 

--- a/test/jpypetest/jvmfinder.py
+++ b/test/jpypetest/jvmfinder.py
@@ -39,7 +39,7 @@ class JVMFinderTest(unittest.TestCase):
             finder = LinuxJVMFinder()
             p = finder.find_libjvm('arbitrary java home')
             self.assertEqual(
-                p, 'jre/lib/amd64/server/libjvm.so', 'wrong jvm returned')
+                p, os.path.join('jre/lib/amd64/server','libjvm.so'), 'wrong jvm returned')
 
         with mock.patch('os.walk') as mockwalk:
             # contains only broken jvms, since server impl is removed
@@ -69,7 +69,7 @@ class JVMFinderTest(unittest.TestCase):
         p = finder._get_from_bin()
 
         self.assertEqual(
-            p, '/usr/lib/jvm/java-6-openjdk-amd64/jre/lib/amd64/server/libjvm.so')
+            p, os.path.join('/usr/lib/jvm/java-6-openjdk-amd64/jre/lib/amd64/server','libjvm.so'))
 
     @unittest.skipIf(sys.version_info[:2] == (2, 6), "skip on py26")
     @mock.patch('platform.mac_ver')

--- a/test/jpypetest/overloads.py
+++ b/test/jpypetest/overloads.py
@@ -75,7 +75,9 @@ class OverloadTestCase(common.JPypeTestCase):
         
     def testPrimitive(self):
         test1 = self.__jp.Test1()
-        self.assertEquals('long', test1.testPrimitive(5))
+        intexpectation = 'int' if not sys.version_info[0] > 2 and sys.maxint == 2**31 - 1 else 'long'
+        self.assertEquals(intexpectation, test1.testPrimitive(5))
+        self.assertEquals('long', test1.testPrimitive(2**31))
         self.assertEquals('byte', test1.testPrimitive(JByte(5)))
         self.assertEquals('Byte', test1.testPrimitive(java.lang.Byte(5)))
         self.assertEquals('short', test1.testPrimitive(JShort(5)))


### PR DESCRIPTION
all these `{s|g}etArrayRange` functions look suspicious, but here a fix for the currently crashing appveyor tests, as i was already looking at these. 

does anybody know where the code is that was used to autogenerate `jp_primitivetypes_autogen_cpp`?