### PR TITLE
Support passing Class objects into java

### DIFF
--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -456,6 +456,13 @@ jvalue JPClass::convertToJava(HostRef* obj)
 		res = a->getValue();
 	}
 
+	if (JPEnv::getHost()->isClass(obj))
+	{
+		JPTypeName name = JPTypeName::fromSimple("java.lang.Class");
+		JPType* type = JPTypeManager::getType(name);
+		res.l = type->convertToJavaObject(obj);
+	}
+
 	return res;
 }
 

--- a/test/harness/jpype/objectwrapper/Test1.java
+++ b/test/harness/jpype/objectwrapper/Test1.java
@@ -41,5 +41,10 @@ public class Test1
 	{
 		return 4;
 	}
+
+	public Object ReturnObject(Object o)
+	{
+		return o;
+	}
 	
 }

--- a/test/jpypetest/objectwrapper.py
+++ b/test/jpypetest/objectwrapper.py
@@ -44,6 +44,17 @@ class ObjectWrapperTestCase(common.JPypeTestCase):
         self.assertEqual(JObject(True).typeName, "java.lang.Boolean")
         self.assertEqual(JObject(False).typeName, "java.lang.Boolean")
 
+    def testPassingClassTypeSucceeds(self):
+        h = JPackage("jpype.objectwrapper").Test1()
+        # Select a convenient java.lang.Class object
+        class_obj = h.getClass()
+
+        # Check that funneling Class obj through java doesn't convert to null
+        result = h.ReturnObject(class_obj)
+
+        self.assertEqual(class_obj, result)
+        self.assertNotEqual(result, None)
+
     @unittest.skip("This seems to be a bug in _jwrapper.py _getDefaultTypeName")
     def testDefaultTypeNameJavaClass(self):
         o = java.lang.String


### PR DESCRIPTION
Hi,

[I'm assuming this is the right place to send jpype patches as you're linked to from PyPi],

Currently, passing Java Class objects from python into any Java method, fails. They're implicitly transformed into null. An example failure case is below, using originell/jpype@95b4467333b48cb06b230cc9c74d342d7343ecf0 follows:

jpype_test.java:

    public class jpype_test {
            public jpype_test() {
            }
    
            public void check_null(Object o) {
                    System.out.println(o);
            }
    }

test.py:

    from jpype import *

    startJVM(getDefaultJVMPath(), "-ea")

    tester = JClass("jpype_test")
    test_obj = tester()
    test_obj.check_null(test_obj)
    test_obj.check_null(test_obj.getClass())

    shutdownJVM()

Example output:

    jmorse at ephesus in /tmp/jpypetest
    $ python test.py
    jpype_test@14ae5a5
    null
    JVM activity report     :
            classes loaded       : 20
    JVM has been shutdown

As shown, the Class object passed in the second check_null call becomes ``null`` rather than being passed as an Object. The attached patch rectifies this by inserting a to-class converter in the relevant function. Once built in,  "class jpype_test" is printed instead of ``null``.

(NB: I've never touched jpype before in my life, take appropriate caution).