### PR TITLE
Updating int types for differing windows compilers

### DIFF
--- a/native/jni_include/jni.h
+++ b/native/jni_include/jni.h
@@ -27,13 +27,18 @@
 #include <stdarg.h>
 
 #ifdef _MSC_VER // broken m$ compiler does not have c99 std header
-    typedef unsigned char           uint8_t;
-    typedef signed   char           int8_t;
-    typedef short int               int16_t;
-    typedef unsigned short int      uint16_t;
-    typedef __int32                 int32_t;
-    typedef __int64                 int64_t;
-    typedef unsigned __int64        uint64_t;
+    #if _MSC_VER >= 1600
+        #include <cstdint>
+    #else
+        typedef __int8              int8_t;
+        typedef __int16             int16_t;
+        typedef __int32             int32_t;
+        typedef __int64             int64_t;
+        typedef unsigned __int8     uint8_t;
+        typedef unsigned __int16    uint16_t;
+        typedef unsigned __int32    uint32_t;
+        typedef unsigned __int64    uint64_t;
+    #endif
 #else
     #include <stdint.h>
 #endif


### PR DESCRIPTION
I was getting errors when I installed JPype on windows because what was there previously redefined certain types.