### PR TITLE
Mark destructor that throws as noexcept(false) for >=C++11

### DIFF
--- a/native/common/include/jp_field.h
+++ b/native/common/include/jp_field.h
@@ -38,7 +38,7 @@ public :
 	/**
 	 * destructor
 	 */
-	virtual ~JPField();
+	virtual ~JPField() NO_EXCEPT_FALSE;
 	
 public :
 	bool isStatic() const;

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -64,6 +64,12 @@
     #define PyUnicode_FromFormat PyString_FromFormat
 #endif
 
+// Define this and use to allow destructors to throw in C++11 or later
+#if __cplusplus >= 201103L
+#define NO_EXCEPT_FALSE noexcept(false)
+#else
+#define NO_EXCEPT_FALSE
+#endif
 
 #include <map>
 #include <string>

--- a/native/common/jp_field.cpp
+++ b/native/common/jp_field.cpp
@@ -63,7 +63,7 @@ JPField::JPField(const JPField& fld)
 	TRACE_OUT;
 }
 
-JPField::~JPField()
+JPField::~JPField() NO_EXCEPT_FALSE
 {
 	TRACE_IN("JPField::~JPField");
 	JPEnv::getJava()->DeleteGlobalRef(m_Field);


### PR DESCRIPTION
In modern C++, destructors default to `noexcept(true)` and anytime it would throw, it calls `terminate()` instead.  When compiling in C++11 or later, such destructors have to be marked `noexcept(false)` to enable throwing of exceptions.  And compile fails if built with CXXFLAGS="-Werror=terminate".  See [dev-python/jpype-0.6.2 : native/.../jpype.h:30:53: error: throw will always call terminate() [-Werror=terminate]](https://bugs.gentoo.org/show_bug.cgi?id=608920).