### PR TITLE
stop JPJavaEnv::GetEnv returning (JNIEnv*)NULL

### DIFF
--- a/native/common/include/jp_javaenv.h
+++ b/native/common/include/jp_javaenv.h
@@ -83,7 +83,7 @@ private :
 	jobject referenceQueue;
 	bool convertStringObjects;
 
-	JNIEnv* getJNIEnv();
+	JNIEnv* getJNIEnv(bool tryAttach=true);
 
 public :	
 	static void load(const string& path);
@@ -132,7 +132,7 @@ public :
 	jthrowable ExceptionOccurred();
 	
 	jint DetachCurrentThread();
-	jint GetEnv(JNIEnv** env);
+	jint GetEnv(JNIEnv** env, bool tryAttach);
 	jint ThrowNew(jclass clazz, const char* msg);
 
 	jint Throw(jthrowable th);

--- a/native/common/jp_javaenv.cpp
+++ b/native/common/jp_javaenv.cpp
@@ -253,6 +253,15 @@ jint JPJavaEnv::GetEnv(JNIEnv** env)
 	// This function must not be put in GOTO_EXTERNAL/RETURN_EXTERNAL because it is called from WITHIN such a block already
 	jint res;
 	res = jvm->functions->GetEnv(jvm, (void**)env, JNI_VERSION_1_2);
+	if(res == JNI_EDETACHED)
+	{
+		AttachCurrentThread();
+		res = jvm->functions->GetEnv(jvm, (void**)env, JNI_VERSION_1_2);
+		if(res != JNI_OK)
+		{
+			RAISE( JPypeException, "Java Subsystem GetEnv() failed");
+		}
+	}
 	return res;
 }
 


### PR DESCRIPTION
GetEnv can fail and return a NULL JNIEnv which crashes in many places
downstream.  This seems to happen when threads are thrashing.

Instead, detect JNI_EDETACHED and do AttachCurrentThread()
then retry GetEnv.  If it fails again RAISE(JPypeException).