### PR TITLE
Imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - '3.3'
   - '3.4'
   - '3.5'
+  - '3.6'
   - 'pypy'
   - 'pypy3'
   - "nightly"
@@ -34,6 +35,10 @@ matrix:
       env: NUMPY=""
     - python: 'pypy3'
       env: NUMPY=""
+    - python: 'nightly'
+      env: NUMPY=""
+    - python: 'nightly'
+      env: NUMPY="--install-option=--disable-numpy"
 
 install:
   - pip install . $NUMPY

--- a/doc/imports.rst
+++ b/doc/imports.rst
@@ -1,0 +1,121 @@
+JImport
+=============
+Module for dynamically loading Java Classes using the import system.
+
+This is a replacement for the jpype.JPackage("com").fuzzy.Main type syntax.
+It features better safety as the objects produced are checked for class
+existence. To use java imports, import the domains package prior to
+importing a java class.
+
+This module supports three different styles of importing java classes.
+
+1) Import of the package path
+--------------------------------
+**import <java_package_path>**  
+
+Importing a series of package creates a path to all classes contained
+in that package.  It does not provide access the the contained packages.
+The root package is added to the global scope.  Imported packages are 
+added to the directory of the base module.
+
+Example:
+  | import java.lang      # Adds java as a module
+  | import java.util
+  |
+  | mystr = java.lang.String('hello')
+  | mylist = java.util.LinkedList()
+  | path = java.nio.files.Paths.get() # ERROR java.nio.files not imported
+
+2) Import of the package path as a module
+--------------------------------
+**import <java_package> as <var>**
+
+A package can be imported as a local variable.  This provides access to
+all java classes in that package.  Contained packages are not available.
+
+Example:
+  | import java.nio as nio
+  | bb = nio.ByteBuffer()
+  | path = nio.file.Path()   # ERROR subpackages file must be imported
+
+3) Import a class from an object
+--------------------------------
+**from <java_package> import <class>[,<class>\*] [as <var>]**
+
+An individual class can be imported from a java package.  This supports
+inner classes as well.
+
+Example:
+  | # Import one class
+  | from java.lang import String
+  | mystr = String('hello')
+  |
+  | # Import multiple classes
+  | from java.lang import Number,Integer,Double
+  |
+  | # Import java inner class java.lang.ProcessBuilder.Redirect
+  | from java.lang.ProcessBuilder import Redirect
+
+This method can also be used to import a static variable or method
+from a class.
+
+Wild card Imports
+=========================
+Wild card imports for classes will import all static method and
+fields into the global namespace.  They will also import any
+inner classes that have been previously be accessed.
+
+Wild card importation of package symbols are not currently supported
+and have unpredictable effects.  Because of the nature of class loaders
+it is not possible to determine what classes are currently loaded.  Some
+classes are loaded by the boot strap loader and thus are not available
+for discovery.
+
+As currently implemented [from <java_package> import \*] will import
+all classes and static variables which have already been imported by
+another import call.  As a result which classes will be imported
+is based on the code pat and thus very unreliable.
+
+It is possible to determine the classes available using Guava for
+java extension jars or for jars specifically loaded in the class path.
+But this is sufficiently unreliable that we recommend not using wildcards
+for any purpose.
+
+Keyword naming
+==================
+Occasionally a java class may contain a python keyword.
+Python keywords as automatically remapped using training underscore.
+
+Example:
+  from org.raise_ import Object  => imports "org.raise.Object"
+
+Controlling Java package imports
+==========================
+By default domains imports four top level domains (TLD) into the python
+import system (com, gov, java, org).  Additional domains can be added
+by calling registerDomain.  Domains can be an alias for a java package
+path.
+
+Example:
+  | domains.registerDomain('jname')
+  | from jname.framework import FrameObject
+  | domains.registerDomain('jlang', alias='java.lang')
+  | from jlang import String
+
+Limitations:
+======================
+* Wildcard imports are unreliable and should be avoided.  Limitations
+  in the Java specification are such that there is no way to get
+  class information at runtime.  Python does not have a good hook
+  to prevent the use of wildcard loading.
+
+* Non-static members can be imported but can not be called without an
+  instance.  Jpype does not provide an easy way to determine which
+  functions objects can be called without an object.
+
+Bugs:
+==========
+* Something in spyder IPython does not play well with the importlib
+  hooks.  Inspect element causes a segmentation fault.  Unable
+  to determine the source.
+

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -36,6 +36,25 @@ def setUsePythonThreadForDeamon(v):
     global _usePythonThreadForDaemon
     _usePythonThreadForDaemon = v
 
+_initializers=[]
+
+def registerJVMInitializer(func):
+    """Register a function to be called after jvm is started"""
+    _initializers.append(func)
+
+def _initialize():
+    _jclass._initialize()
+    _jarray._initialize()
+    _jwrapper._initialize()
+    _jproxy._initialize()
+    _jexception._initialize()
+    _jcollection._initialize()
+    _jobject._initialize()
+    _properties._initialize()
+    nio._initialize()
+    reflect._initialize()
+    for func in _initializers:
+        func()
 
 def isJVMStarted() :
     return _jpype.isStarted()
@@ -48,16 +67,7 @@ def startJVM(jvm, *args):
     :param args: Arguments to give to the JVM
     """
     _jpype.startup(jvm, tuple(args), True)
-    _jclass._initialize()
-    _jarray._initialize()
-    _jwrapper._initialize()
-    _jproxy._initialize()
-    _jexception._initialize()
-    _jcollection._initialize()
-    _jobject._initialize()
-    _properties._initialize()
-    nio._initialize()
-    reflect._initialize()
+    _initialize()
 
     # start the reference daemon thread
     if _usePythonThreadForDaemon:
@@ -67,15 +77,7 @@ def startJVM(jvm, *args):
 
 def attachToJVM(jvm):
     _jpype.attach(jvm)
-
-    _jclass._initialize()
-    _jarray._initialize()
-    _jwrapper._initialize()
-    _jproxy._initialize()
-    _jexception._initialize()
-    _jcollection._initialize()
-    _jobject._initialize()
-    _properties._initialize()
+    _initialize()
 
 def shutdownJVM():
     _refdaemon.stop()

--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+# *****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# *****************************************************************************
+
+# Optional jpype module to support:
+#   import <java_pkg> [ as <name> ]
+#   import <java_pkg>.<java_class> [ as <name> ]
+#   from <java_pkg> import <java_class>[,<java_class>*]
+#   from <java_pkg> import <java_class> [ as <name> ]
+#   from <java_pkg>.<java_class> import <java_static> [ as <name> ]
+#   from <java_pkg>.<java_class> import <java_inner> [ as <name> ]
+#
+#   jpype.imports.registerDomain(moduleName, alias=<java_pkg>)
+#   jpype.imports.registerImportCustomizer(JImportCustomizer)
+# 
+# Requires Python 3.6 or later
+# Usage:
+#   import jpype
+#   import jpype.imports
+#   <start or attach jvm>
+#   # Import java packages as modules
+#   from java.lang import String
+
+try:
+    from importlib.machinery import ModuleSpec as _ModuleSpec
+    from types import ModuleType as _ModuleType
+except Exception:
+    raise ImportError("jpype.imports Not supported for Python 2")
+import sys as _sys
+import keyword as _keyword
+from ._jclass import JClass as _JClass
+from ._jclass import _JavaClass as _JavaClass
+from ._core import registerJVMInitializer as _jinit
+
+__all__ = ["registerImportCustomizer", "registerDomain", "JImportCustomizer"]
+_initialized = False
+_exportTypes = ()
+_modifier = None
+
+# %% Utility
+def _keywordUnwrap(name):
+    if not name.endswith('_'):
+        return name
+    if _keyword.iskeyword(name[:-1]):
+        return name[:-1]
+    return name
+
+def _keywordWrap(name):
+    if name in _keyword.kwlist:
+        return name + "_"
+    return name
+
+def _getJavaClass(javaname):
+    try:
+        return _JClass(javaname)
+    except Exception:
+        return None
+
+def _copyProperties(out, mc):
+    for v in dir(mc):
+        # Skip private members
+        if v.startswith('_'):
+            continue
+
+        # Copy properties
+        attr = getattr(mc, v)
+        if isinstance(attr, property):
+            out[v] = attr
+
+def _getStaticMethods(cls):
+    global _modifier
+    static = {}
+    for u in cls.__javaclass__.getMethods():
+        mod=int(u.getModifiers())
+        static=_modifier.isStatic(mod)
+        if not _modifier.isStatic(mod):
+            continue
+        name = _keywordWrap(u.getName())
+        static[name] = getattr(cls, name)
+    return static
+
+def _copyStaticMethods(out, cls):
+    for u, v in _getStaticMethods(cls).items():
+        out[u] = v
+
+# %% Customizer
+_CUSTOMIZERS = []
+
+def registerImportCustomizer(customizer):
+    """ Import customizers can be used to import python packages
+    into java modules automatically.
+    """
+    _CUSTOMIZERS.append(customizer)
+
+# Support hook for placing other things into the java tree
+class JImportCustomizer(object):
+    """ Base class for Import customizer.
+
+    Import customizers should implement canCustomize and getSpec.
+
+    Example:
+      | # Site packages for each java package are stored under $DEVEL/<java_pkg>/py
+      | class SiteCustomizer(jpype.imports.JImportCustomizer):
+      |     def canCustomize(self, name):
+      |         if name.startswith('org.mysite') and name.endswith('.py'):
+      |             return True
+      |         return False
+      |     def getSpec(self, name):
+      |         pname = name[:-3]
+      |         devel = os.environ.get('DEVEL')
+      |         path = os.path.join(devel, pname,'py','__init__.py')
+      |         return importlib.util.spec_from_file_location(name, path)
+   """
+    def canCustomize(self, name):
+        """ Determine if this path is to be treated differently 
+
+        Return:
+            True if an alternative spec is required.
+        """
+        return False
+
+    def getSpec(self, name):
+        """ Get the module spec for this module. 
+        """
+        raise Exception
+
+# %% Import
+class _JImport(object):
+    """ (internal) Base class for import java modules """
+    # Module requirements
+    __doc__ = None
+    __loader__ = None
+    __path__ = "<java>"
+    __package__ = "java"
+
+    def __init__(self, name):
+        pass
+
+    def __getattr__(self, name):
+        if name.startswith('_'):
+            return object.__getattribute__(self, name)
+
+        name = _keywordUnwrap(name)
+
+        # Inner class support
+        jname = object.__getattribute__(self, '__javaname__')
+        try:
+            object.__getattribute__(self, '__javaclass__')
+            jname = "$".join([jname, name])
+        except AttributeError:
+            jname = ".".join([jname, name])
+
+        # Get the class (if it exists)
+        jtype = _getJavaClass(jname)
+        if jtype:
+            # Cache it for later
+            object.__setattr__(self, name, jtype)
+            return jtype
+
+        # If the java class does not exist, throw a ClassNotFound exception
+        raise Exception("Unable to find java class " + jname)
+
+    def __setattr__(self, name, value):
+        if name.startswith('__'):
+            raise AttributeError("Module does not allow setting of %s" % name)
+        if hasattr(value, '__javaclass__'):
+            return object.__setattr__(self, name, getattr(value, '__javaclass__'))
+        if isinstance(value, (_JImport, _ModuleType)):
+            return object.__setattr__(self, name, value)
+        raise AttributeError("JImport may not set attribute %s" % name)
+
+
+# In order to get properties to be attached to the _JImport class,
+# we must create a dynamic class between
+def _JImportFactory(spec, javaname, cls=_JImport):
+    """ (internal) Factory for creating java modules dynamically.
+
+    This is needed to create a new type node to hold static methods.
+    """
+    def init(self, name):
+        # Call the base class
+        cls.__init__(self, name)
+
+    def getall(self):
+        global _exportTypes
+        d1 = self.__dict__.items()
+        d2 = self.__class__.__dict__.items()
+        local = [name for name, attr in d1 if not name.startswith('_')
+                and isinstance(attr, _exportTypes)]
+        glob = [name for name, attr in d2 if not name.startswith('_')
+                and isinstance(attr, _exportTypes)]
+        local.extend(glob)
+        return local
+
+    # Set up a new class for this type
+    bases = [cls]
+    members = {
+        "__init__": init,
+        "__javaname__": javaname,
+        "__name__": spec.name,
+        "__all__": property(getall),
+        "__spec__": spec,
+    }
+
+    # Is this module also a class, if so insert class info
+    jclass = _getJavaClass(javaname)
+    if jclass:
+        # Mark this as a class (will cause children to be inner classes)
+        members['__javaclass__'] = jclass
+
+        # Exposed static members as part of the module
+        _copyProperties(members, jclass.__metaclass__)
+        _copyStaticMethods(members, jclass)
+
+    return type("module." + spec.name, tuple(bases), members)
+
+def _JModule(spec, javaname):
+    """ (internal) Front end for creating a java module dynamically """
+    cls = _JImportFactory(spec, javaname)
+    out = cls(spec.name)
+    return out
+
+# %% Finder
+class _JImportLoader:
+    """ (internal) Finder hook for importlib. """
+    def find_spec(self, name, path, target):
+        parts = name.split('.', 1)
+        if not parts[0] in _JDOMAINS:
+            return None
+
+        # Support for external modules in java tree
+        for customizer in _CUSTOMIZERS:
+            if customizer.canCustomize(name):
+                return customizer.getSpec(name)
+
+        # Import the java module
+        return _ModuleSpec(name, self)
+
+    """ (internal) Loader hook for importlib. """
+    def create_module(self, spec):
+        global _initialized
+        if not _initialized:
+            raise RuntimeError("Attempt to create modules without jvm")
+
+        # Handle creating the java name based on the path
+        parts = spec.name.split('.')
+        if len(parts) == 1:
+            return _JModule(spec, _JDOMAINS[spec.name])
+
+        # Use the parent module to simplify name mangling
+        base = _sys.modules[".".join(parts[:-1])]
+
+        # Support of inner classes
+        jbasename = object.__getattribute__(base, '__javaname__')
+        try:
+            object.__getattribute(base, '__javaclass__')
+            javaname = "$".join([jbasename, _keywordUnwrap(parts[-1])])
+        except AttributeError:
+            javaname = ".".join([jbasename, _keywordUnwrap(parts[-1])])
+
+        return _JModule(spec, javaname)
+
+    def exec_module(self, fullname):
+        pass
+
+# Install hooks into python importlib
+_sys.meta_path.append(_JImportLoader())
+
+# %% Domains
+_JDOMAINS = {}
+
+def registerDomain(mod, alias=None):
+    """ Add a java domain to python as a dynamic module.
+
+    Args:
+        mod is the name of the dynamic module
+        alias is the name of the java path. (optional)
+    """
+    if not alias:
+        alias = mod
+    _JDOMAINS[mod] = alias
+
+# Preregister common top level domains
+registerDomain('com')
+registerDomain('gov')
+registerDomain('java')
+registerDomain('org')
+
+# %% Initialize
+def _initialize():
+    global _exportTypes
+    global _initialized 
+    global _modifier
+    _initialized = True
+    _JMethod = type(_JClass('java.lang.Class').forName)
+    _modifier = _JClass('java.lang.reflect.Modifier')
+    _exportTypes = (property, _JavaClass, _JImport, _JMethod)
+
+_jinit(_initialize)
+

--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -85,9 +85,7 @@ def _getStaticMethods(cls):
     global _modifier
     static = {}
     for u in cls.__javaclass__.getMethods():
-        mod=int(u.getModifiers())
-        static=_modifier.isStatic(mod)
-        if not _modifier.isStatic(mod):
+        if not _modifier.isStatic(u.getModifiers()):
             continue
         name = _keywordWrap(u.getName())
         static[name] = getattr(cls, name)
@@ -265,6 +263,8 @@ class _JImportLoader:
         base = _sys.modules[".".join(parts[:-1])]
 
         # Support of inner classes
+        if not isinstance(base,_JImport):
+            return getattr(base, parts[-1])
         jbasename = object.__getattribute__(base, '__javaname__')
         try:
             object.__getattribute(base, '__javaclass__')

--- a/test/jpypetest/imports.py
+++ b/test/jpypetest/imports.py
@@ -1,0 +1,72 @@
+#*****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#*****************************************************************************
+import jpype
+import sys
+import logging
+import time
+from . import common
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
+def haveJImports():
+    try:
+        import jpype.imports
+        return True
+    except ImportError:
+        return False
+
+def isJavaClass(tp):
+    return isinstance(tp, jpype._jclass._JavaClass)
+
+class ImportsTestCase(common.JPypeTestCase):
+    def setUp(self):
+#        logger = logging.getLogger(__name__)
+#        logger.info("TEST:JImports")
+        common.JPypeTestCase.setUp(self)
+        self.__jp = self.jpype.attr
+
+    @unittest.skipUnless(haveJImports(), "jpype.imports not available")
+    def testImportPackage(self):
+        import java.lang
+        self.assertTrue(isJavaClass(java.lang.String))
+
+    @unittest.skipUnless(haveJImports(), "jpype.imports not available")
+    def testImportClass(self):
+        from java.lang import String
+        self.assertTrue(isJavaClass(String))
+
+    @unittest.skipUnless(haveJImports(), "jpype.imports not available")
+    def testImportClassAs(self):
+        from java.lang import String as Str
+        self.assertTrue(isJavaClass(Str))
+
+    @unittest.skipUnless(haveJImports(), "jpype.imports not available")
+    def testImportClassMultiple(self):
+        from java.lang import Number, Integer, Double
+        self.assertTrue(isJavaClass(Number))
+        self.assertTrue(isJavaClass(Integer))
+        self.assertTrue(isJavaClass(Double))
+
+    @unittest.skipUnless(haveJImports(), "jpype.imports not available")
+    def testImportStatic(self):
+        from java.lang.ProcessBuilder import Redirect
+        self.assertTrue(isJavaClass(Redirect))
+
+# FIXME add test for static member variable imports and other edge cases.        


### PR DESCRIPTION
This is a proposed system to support safer imports of java classes.  Unfortunately it only works for Python 3.6 as the support hooks for 2.7 are not good enough.   It prevents accidental use of non-imported classes which improves type safety and makes python code more robust to code refactors of the java code.  We have been using this in module for a month, but have not used it on many alternative platforms.  It supports some slight exotic features such as placing python code into netbeans projects.  We are working on directly being able to store a python package to support the use of java classes in the jar, but that support is not ready for distribution.   I have included the basic imports system with hooks and the corresponding documentation.  Testing scripts will still need to be developed. 