### PR TITLE
Boxed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,6 @@ install:
   - ant -f test/build.xml
 
 script:
+  - jdk_switcher use oraclejdk8
   - python -c "import jpype"
   - python test/testsuite.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,5 @@ install:
   - ant -f test/build.xml
 
 script:
-  - jdk_switcher use oraclejdk8
   - python -c "import jpype"
   - python test/testsuite.py

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -4,24 +4,25 @@ Changelog
 This changelog *only* contains changes from the *first* pypi release (0.5.4.3) onwards.
 
 - **Next version - unreleased**
-- **0.6.2 - 2017-01-13**
 
-  - Fix JVM location for OSX.
-  - Fix a method overload bug.
-  - Add support for synthetic methods 
   - Added support for automatic conversion of boxed types.  
      - Boxed types automatically convert to python primitives.
      - Boxed types automatically convert to java primitives when resolving functions.
      - Functions taking boxed or primitives still resolve based on closest match.
+
   - Python integer primitives will implicitly match java float and double as per
     Java specification.
-  
+
+-  **0.6.2 - 2017-01-13**
+
+  - Fix JVM location for OSX.
+  - Fix a method overload bug.
+  - Add support for synthetic methods 
+ 
 - **0.6.1 - 2015-08-05**
 
   - Fix proxy with arguments issue.
-
   - Fix Python 3 support for Windows failing to import winreg.
-
   - Fix non matching overloads on iterating java collections.
 
 - **0.6.0 - 2015-04-13**

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -13,7 +13,7 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
      - Boxed types automatically convert to python primitives.
      - Boxed types automatically convert to java primitives when resolving functions.
      - Functions taking boxed or primitives still resolve based on closest match.
-  - java float and double can be implicitly matched with integer types as per
+  - Python integer primitives will implicitly match java float and double as per
     Java specification.
   
 - **0.6.1 - 2015-08-05**

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -9,6 +9,12 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
   - Fix JVM location for OSX.
   - Fix a method overload bug.
   - Add support for synthetic methods 
+  - Added support for automatic conversion of boxed types.  
+     - Boxed types automatically convert to python primitives.
+     - Boxed types automatically convert to java primitives when resolving functions.
+     - Functions taking boxed or primitives still resolve based on closest match.
+  - java float and double can be implicitly matched with integer types as per
+    Java specification.
   
 - **0.6.1 - 2015-08-05**
 

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -309,9 +309,9 @@ Java **String** is converted to Python **unicode**.
 
 Java **arrays** are converted to **JArray**.
 
-Java **boxed** types are converted to extensions of python primitives on return.  
+Java **boxed** types are converted to extensions of python primitives on return.
 
-All other Java objects are converted to **JavaObject**s.
+All other Java objects are converted to **JavaObjects**.
 
 Java **Class** is converted to **JavaClass**.
 
@@ -321,13 +321,13 @@ Boxed types
 ~~~~~~~~~~~
 
 Both python primitives and Boxed types are immutable.  Thus boxed types are
-inherited from the python primitives.  The means that a boxed type regardless
+inherited from the python primitives.  This means that a boxed type regardless
 of whether produced as a return or created explicitely are treated as python
-types.  This means that they will obey all the conversion rules corresponding
-to a python type.  In addition, they will produce an exact match with their
-corresponding java type.  The type conversion for this is somewhat looser than
-java.  While java provides automatic unboxing of a Integer to a double, jpype
-can implicitly convert Integer to a Double.
+types.  They will obey all the conversion rules corresponding
+to a python type as implicit matches.  In addition, they will produce an exact 
+match with their corresponding java type.  The type conversion for this is 
+somewhat looser than java.  While java provides automatic unboxing of a Integer 
+to a double primitive, jpype can implicitly convert Integer to a Double boxed.
 
 JProxy
 ------

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -227,8 +227,8 @@ types. These levels are:
 ============ ========== ========= =========== ========= ========== ========== =========== ========= ========== ========== =========== =========
 Python\\Java    byte      short       int       long       float     double     boolean     char      String      Array     Object      Class   
 ============ ========== ========= =========== ========= ========== ========== =========== ========= ========== ========== =========== =========
-    int       I [1]_     I [1]_       X          I                             X [10]_                                               
-   long       I [1]_     I [1]_     I [1]_       X                                                                                  
+    int       I [1]_     I [1]_       X          I        I [11]_    I [11]_    X [10]_                                               
+   long       I [1]_     I [1]_     I [1]_       X        I [11]_    I [11]_                                                                   
    float                                                  I [1]_       X                                                            
  sequence                                                                                                                           
 dictionary                                                                                                                          
@@ -247,6 +247,7 @@ dictionary
   JObject                                                                                                       I/X [6]_    I/X [7]_
 JavaObject                                                                                                                  I [8]_
  JavaClass                                                                                                                  I [9]_        X     
+ "Boxed"      I [12]_    I [12]_    I [12]_     I [12]_   I [12]_    I [12]_    I [12]_                                     I/X [8]_ 
 ============ ========== ========= =========== ========= ========== ========== =========== ========= ========== ========== =========== =========
 
 .. [1] Conversion will occur if the Python value fits in the Java
@@ -279,6 +280,15 @@ JavaObject                                                                      
 .. [10] Only the values True and False are implicitly converted to
         booleans.
 
+.. [11] Java defines conversions from integer types to floating point 
+        types as implicit conversion.  Java's conversion rules are based
+        on the range and can be lossy.
+        See (http://stackoverflow.com/questions/11908429/java-allows-implicit-conversion-of-int-to-float-why)
+
+.. [12] Java boxed types are mapped to python primitives, but will 
+        produce an implicit conversion even if the python type is an exact 
+        match.  This is to allow for resolution between methods 
+        that take both a java primitve and a java boxed type.
 
 Converting from Java to Python
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -299,12 +309,25 @@ Java **String** is converted to Python **unicode**.
 
 Java **arrays** are converted to **JArray**.
 
+Java **boxed** types are converted to extensions of python primitives on return.  
+
 All other Java objects are converted to **JavaObject**s.
 
 Java **Class** is converted to **JavaClass**.
 
 Java array **Class** is converted to **JavaArrayClass**.
 
+Boxed types
+~~~~~~~~~~~
+
+Both python primitives and Boxed types are immutable.  Thus boxed types are
+inherited from the python primitives.  The means that a boxed type regardless
+of whether produced as a return or created explicitely are treated as python
+types.  This means that they will obey all the conversion rules corresponding
+to a python type.  In addition, they will produce an exact match with their
+corresponding java type.  The type conversion for this is somewhat looser than
+java.  While java provides automatic unboxing of a Integer to a double, jpype
+can implicitly convert Integer to a Double.
 
 JProxy
 ------

--- a/jpype/__init__.py
+++ b/jpype/__init__.py
@@ -20,10 +20,15 @@ from ._jarray import *
 from ._jwrapper import *
 from ._jproxy import *
 from ._jexception import *
+from ._jboxed import *
 from ._core import *
 from ._gui import *
 
 from . import JClassUtil
+
+# Support for isinstance(obj, )
+from ._jclass import _JavaObject as JavaObject
+from ._jclass import _JavaClass as JavaClass
 
 __version_info__ = (0, 6, 2)
 __version__ = ".".join(str(i) for i in __version_info__)

--- a/jpype/_jboxed.py
+++ b/jpype/_jboxed.py
@@ -1,0 +1,107 @@
+import jpype
+from ._jclass import _JavaObject
+from ._jclass import _isJavaCtor
+from ._jwrapper import _JWrapper
+import sys as _sys
+
+#Python2/3 support
+if _sys.version_info > (3,):
+    _long  =  int
+else:
+    _long  =  long
+
+__all__=[]
+   
+# Temporary JavaObject wrapper to call Java Methods in __new__
+class _JTmp(_JavaObject):
+    def __init__(self, jp):
+        self.__javaobject__ = jp
+
+class _JBoxedShort(int):
+    __metaclass__ = int.__class__
+    def __new__(cls, *args, **kwargs):
+        try:
+            if isinstance(args[0], (int, _long)):
+                return int.__new__(cls, args[0])
+            if isinstance(args[0], _JWrapper):
+                return int.__new__(cls, args[0]._pyv)
+        except OverflowError:
+            raise TypeError("Overflow")
+        if _isJavaCtor(args):
+            return int.__new__(cls, cls.shortValue(_JTmp(args[0][1])))
+        raise ValueError("Invalid arguments %s"%args[0])
+
+class _JBoxedInteger(int):
+    __metaclass__ = int.__class__
+    def __new__(cls, *args, **kwargs):
+        try:
+            if isinstance(args[0], (int, _long)):
+                return int.__new__(cls, args[0])
+            if isinstance(args[0], _JWrapper):
+                return int.__new__(cls, args[0]._pyv)
+        except OverflowError:
+            raise TypeError("Overflow")
+        if _isJavaCtor(args):
+            return int.__new__(cls, cls.intValue(_JTmp(args[0][1])))
+        raise ValueError("Invalid arguments")
+
+class _JBoxedLong(_long):
+    __metaclass__ = _long.__class__
+    def __new__(cls, *args, **kwargs):
+        if isinstance(args[0], (int, _long)):
+            return _long.__new__(cls, args[0])
+        if isinstance(args[0], _JWrapper):
+            return _long.__new__(cls, args[0]._pyv)
+        if _isJavaCtor(args):
+            return _long.__new__(cls, cls.longValue(_JTmp(args[0][1])))
+        raise ValueError("Invalid arguments")
+
+class _JBoxedFloat(float):
+    __metaclass__ = float.__class__
+    def __new__(cls, *args, **kwargs):
+        if isinstance(args[0], (int, _long,float)):
+            return float.__new__(cls, args[0])
+        if isinstance(args[0], _JWrapper):
+            return int.__new__(cls, args[0]._pyv)
+        if _isJavaCtor(args):
+            return float.__new__(cls, cls.floatValue(_JTmp(args[0][1])))
+        raise ValueError("Invalid arguments")
+
+class _JBoxedDouble(float):
+    __metaclass__ = float.__class__
+    def __new__(cls, *args, **kwargs):
+        if isinstance(args[0], (int, _long,float)):
+            return float.__new__(cls, args[0])
+        if isinstance(args[0], _JWrapper):
+            return int.__new__(cls, args[0]._pyv)
+        if _isJavaCtor(args):
+            return float.__new__(cls, cls.doubleValue(_JTmp(args[0][1])))
+        raise ValueError("Invalid arguments")
+
+_BOXED = {
+        'java.lang.Short': _JBoxedShort,
+        'java.lang.Integer': _JBoxedInteger,
+        'java.lang.Long': _JBoxedLong,
+        'java.lang.Float': _JBoxedFloat,
+        'java.lang.Double': _JBoxedDouble,
+        }
+
+class _BoxedCustomizer(object):
+    def canCustomize(self, name, jc):
+        if name in _BOXED:
+            return True
+        return False
+
+    def customize(self, name, jc, bases, members):
+        cls=_BOXED[name]
+        bases.append(cls)
+        members['__eq__']=cls.__eq__
+        members['__ne__']=cls.__ne__
+        if hasattr(cls, '__cmp__'):
+            members['__cmp__']=cls.__cmp__
+
+def _initialize():
+    from ._jclass import registerClassCustomizer
+    registerClassCustomizer(_BoxedCustomizer())
+
+_initialize()

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -25,7 +25,6 @@ _SPECIAL_CONSTRUCTOR_KEY = "This is the special constructor key"
 _JAVAOBJECT = None
 _JAVATHROWABLE = None
 _COMPARABLE = None
-_RUNTIMEEXCEPTION = None
 
 _CUSTOMIZERS = []
 
@@ -33,6 +32,10 @@ _COMPARABLE_METHODS = {
         "__cmp__": lambda self, o: self.compareTo(o)
         }
 
+class _NotLoaded(object):
+    def PYEXC(self,s):
+        return RuntimeError("JVM not loaded: %s"%s)
+_RUNTIMEEXCEPTION = _NotLoaded()
 
 def _initialize():
     global _COMPARABLE, _JAVAOBJECT, _JAVATHROWABLE, _RUNTIMEEXCEPTION
@@ -40,7 +43,8 @@ def _initialize():
     _JAVAOBJECT = JClass("java.lang.Object")
     _JAVATHROWABLE = JClass("java.lang.Throwable")
     _RUNTIMEEXCEPTION = JClass("java.lang.RuntimeException")
-    _jpype.setJavaLangObjectClass(_JAVAOBJECT)
+#    _jpype.setJavaLangObjectClass(_JAVAOBJECT)
+    _jpype.setJavaLangObjectClass(_JavaObject)
     _jpype.setGetClassMethod(_getClassFor)
     _jpype.setSpecialConstructorKey(_SPECIAL_CONSTRUCTOR_KEY)
 
@@ -74,6 +78,13 @@ def _javaNew(self, *args):
 def _javaExceptionNew(self, *args):
     return Exception.__new__(self)
 
+
+def _isJavaCtor(args):
+    if len(args)==1 and isinstance(args[0], tuple) \
+            and args[0][0] is _SPECIAL_CONSTRUCTOR_KEY:
+        return True
+    return False
+ 
 
 def _javaInit(self, *args):
     object.__init__(self)
@@ -121,7 +132,20 @@ class _MetaClassForMroOverride(type):
     def mro(cls):
         return _mro_override_topsort(cls)
 
+
+class _JavaObject(object):
+    """ Base class for all Java Objects. 
+
+        Use isinstance(obj, jpype.JavaObject) to test for a object.
+    """
+    pass
+
+
 class _JavaClass(type):
+    """ Base class for all Java Class types. 
+
+        Use isinstance(obj, jpype.JavaClass) to test for a class.
+    """
     def __new__(cls, jc):
         bases = []
         name = jc.getName()
@@ -137,7 +161,9 @@ class _JavaClass(type):
                 "__getattribute__": _javaGetAttr,
                 }
 
-        if name == 'java.lang.Object' or jc.isPrimitive():
+        if name == 'java.lang.Object':
+            bases.append(_JavaObject)
+        elif jc.isPrimitive():
             bases.append(object)
         elif not jc.isInterface():
             bjc = jc.getBaseClass()
@@ -192,12 +218,10 @@ class _JavaClass(type):
         # Prepare the meta-metaclass
         meta_bases = []
         for i in bases:
-            if i is object:
+            if i is object or i is _JavaObject:
                 meta_bases.append(cls)
             else:
                 meta_bases.append(i.__metaclass__)
-
-
 
         static_fields['mro'] = _mro_override_topsort
 

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -25,17 +25,13 @@ _SPECIAL_CONSTRUCTOR_KEY = "This is the special constructor key"
 _JAVAOBJECT = None
 _JAVATHROWABLE = None
 _COMPARABLE = None
+_RUNTIMEEXCEPTION = None
 
 _CUSTOMIZERS = []
 
 _COMPARABLE_METHODS = {
         "__cmp__": lambda self, o: self.compareTo(o)
         }
-
-class _NotLoaded(object):
-    def PYEXC(self,s):
-        return RuntimeError("JVM not loaded: %s"%s)
-_RUNTIMEEXCEPTION = _NotLoaded()
 
 def _initialize():
     global _COMPARABLE, _JAVAOBJECT, _JAVATHROWABLE, _RUNTIMEEXCEPTION

--- a/jpype/_jwrapper.py
+++ b/jpype/_jwrapper.py
@@ -32,6 +32,7 @@ def _initialize():
 class _JWrapper(object):
     def __init__(self, v):
         if v is not None:
+            self._pyv = v
             self._value = _jpype.convertToJValue(self.typeName, v)
         else:
             self._value = None

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -19,18 +19,44 @@
 
 // Define this to generate the trace calls
 
-// Define this to make the trace calls do their output. If you change this only the core.cpp needs to be recompiled
+// Define this to make the trace calls do their output. 
 //#define TRACING
+
+// Define this to make the trace calls for referencing.
+//#define MTRACING
+
 #ifdef TRACING
-#define JPYPE_TRACING_INTERNAL
+  #define JPYPE_TRACING_INTERNAL
 #endif
 #define JPYPE_TRACING_OUTPUT cerr
 
-#define TRACE_IN(n) JPypeTracer _trace(n); try {
-#define TRACE_OUT } catch(...) { _trace.gotError(); throw; }
-#define TRACE1(m) _trace.trace(m)
-#define TRACE2(m,n) _trace.trace(m,n)
-#define TRACE3(m,n,o) _trace.trace(m,n,o)
+#ifdef TRACING
+  #define TRACE_IN(n) JPypeTracer _trace(n); try {
+  #define TRACE_OUT } catch(...) { _trace.gotError(); throw; }
+  #define TRACE1(m) _trace.trace(m)
+  #define TRACE2(m,n) _trace.trace(m,n)
+  #define TRACE3(m,n,o) _trace.trace(m,n,o)
+#else
+  #define TRACE_IN(n)
+  #define TRACE_OUT
+  #define TRACE1(m)
+  #define TRACE2(m,n)
+  #define TRACE3(m,n,o)
+#endif
+
+#ifdef MTRACING
+  #define MTRACE_IN(n) JPypeTracer _trace(n); try {
+  #define MTRACE_OUT } catch(...) { _trace.gotError(); throw; }
+  #define MTRACE1(m) _trace.trace(m)
+  #define MTRACE2(m,n) _trace.trace(m,n)
+  #define MTRACE3(m,n,o) _trace.trace(m,n,o)
+#else
+  #define MTRACE_IN(n)
+  #define MTRACE_OUT
+  #define MTRACE1(m)
+  #define MTRACE2(m,n)
+  #define MTRACE3(m,n,o)
+#endif
 
 #ifdef WIN32
 	#define JPYPE_WIN32

--- a/native/common/jp_javaenv.cpp
+++ b/native/common/jp_javaenv.cpp
@@ -139,50 +139,50 @@ int JPJavaEnv::DestroyJavaVM()
 
 void JPJavaEnv::DeleteLocalRef(jobject obj)
 {
-	TRACE_IN("JPJavaEnv::DeleteLocalRef");
-	TRACE1((long)obj);
+	MTRACE_IN("JPJavaEnv::DeleteLocalRef");
+	MTRACE1((long)obj);
 	JNIEnv* env = getJNIEnv();
 	if (env != NULL)
 	{
 		env->functions->DeleteLocalRef(env, obj);
 	}
-	TRACE_OUT;
+	MTRACE_OUT;
 }
 
 void JPJavaEnv::DeleteGlobalRef(jobject obj)
 {
-	TRACE_IN("JPJavaEnv::DeleteGlobalRef");
-	TRACE1((long)obj);
+	MTRACE_IN("JPJavaEnv::DeleteGlobalRef");
+	MTRACE1((long)obj);
 	JNIEnv* env = getJNIEnv();
 	if (env != NULL)
 	{
 		env->functions->DeleteGlobalRef(env, obj);
 	}
-	TRACE_OUT;
+	MTRACE_OUT;
 }
 
 jobject JPJavaEnv::NewLocalRef(jobject a0)
 {
-	TRACE_IN("JPJavaEnv::NewLocalRef");
-	TRACE1((long)a0);
+	MTRACE_IN("JPJavaEnv::NewLocalRef");
+	MTRACE1((long)a0);
 	jobject res;
 	JNIEnv* env = getJNIEnv();
 	res = env->functions->NewLocalRef(env, a0);
-	TRACE1((long)res); //, JPJni::getClassName(a0).getSimpleName());
+	MTRACE1((long)res); //, JPJni::getClassName(a0).getSimpleName());
 	return res;
-	TRACE_OUT;
+	MTRACE_OUT;
 }
 
 jobject JPJavaEnv::NewGlobalRef(jobject a0)
 {
-	TRACE_IN("JPJavaEnv::NewGlobalRef");
-	TRACE1((long)a0);
+	MTRACE_IN("JPJavaEnv::NewGlobalRef");
+	MTRACE1((long)a0);
 	jobject res;
 	JNIEnv* env = getJNIEnv();
 	res = env->functions->NewGlobalRef(env, a0);
-	TRACE1((long)res); //, JPJni::getClassName(a0).getSimpleName());
+	MTRACE1((long)res); //, JPJni::getClassName(a0).getSimpleName());
 	return res;
-	TRACE_OUT;
+	MTRACE_OUT;
 }
 
 

--- a/native/common/jp_primitivetypes.cpp
+++ b/native/common/jp_primitivetypes.cpp
@@ -235,6 +235,10 @@ EMatchType JPIntType::canConvertToJava(HostRef* obj)
 
 	if (JPEnv::getHost()->isInt(obj))
 	{
+		if (JPEnv::getHost()->isObject(obj))
+		{
+			return _implicit;
+		}
 		return _exact;
 	}
 
@@ -322,6 +326,10 @@ EMatchType JPLongType::canConvertToJava(HostRef* obj)
 
 	if (JPEnv::getHost()->isLong(obj))
 	{
+		if (JPEnv::getHost()->isObject(obj))
+		{
+			return _implicit;
+		}
 		return _exact;
 	}
 
@@ -333,8 +341,6 @@ EMatchType JPLongType::canConvertToJava(HostRef* obj)
 			return _exact;
 		}
 	}
-
-
 
 	return _none;
 }
@@ -390,6 +396,10 @@ EMatchType JPFloatType::canConvertToJava(HostRef* obj)
 
 	if (JPEnv::getHost()->isFloat(obj))
 	{
+		if (JPEnv::getHost()->isObject(obj))
+		{
+			return _implicit;
+		}
 		return _implicit;
 	}
 
@@ -402,6 +412,11 @@ EMatchType JPFloatType::canConvertToJava(HostRef* obj)
 		}
 	}
 
+	// Java allows conversion to any type with a longer range even if lossy
+	if (JPEnv::getHost()->isInt(obj) || JPEnv::getHost()->isLong(obj))
+	{
+		return _implicit;
+	}
 
 	return _none;
 }
@@ -412,6 +427,14 @@ jvalue JPFloatType::convertToJava(HostRef* obj)
 	if (JPEnv::getHost()->isWrapper(obj))
 	{
 		return JPEnv::getHost()->getWrapperValue(obj);
+	}
+	else if (JPEnv::getHost()->isInt(obj))
+	{
+		res.d = JPEnv::getHost()->intAsInt(obj);;
+	}
+	else if (JPEnv::getHost()->isLong(obj))
+	{
+		res.d = JPEnv::getHost()->longAsLong(obj);;
 	}
 	else
 	{
@@ -461,6 +484,10 @@ EMatchType JPDoubleType::canConvertToJava(HostRef* obj)
 
 	if (JPEnv::getHost()->isFloat(obj))
 	{
+	  if (JPEnv::getHost()->isObject(obj))
+		{
+			return _implicit;
+		}
 		return _exact;
 	}
 
@@ -473,6 +500,12 @@ EMatchType JPDoubleType::canConvertToJava(HostRef* obj)
 		}
 	}
 
+	// Java allows conversion to any type with a longer range even if lossy
+	if (JPEnv::getHost()->isInt(obj) || JPEnv::getHost()->isLong(obj))
+	{
+		return _implicit;
+	}
+
 	return _none;
 }
 
@@ -482,6 +515,14 @@ jvalue JPDoubleType::convertToJava(HostRef* obj)
 	if (JPEnv::getHost()->isWrapper(obj))
 	{
 		return JPEnv::getHost()->getWrapperValue(obj);
+	}
+	else if (JPEnv::getHost()->isInt(obj))
+	{
+		res.d = JPEnv::getHost()->intAsInt(obj);;
+	}
+	else if (JPEnv::getHost()->isLong(obj))
+	{
+		res.d = JPEnv::getHost()->longAsLong(obj);;
 	}
 	else
 	{
@@ -537,8 +578,6 @@ EMatchType JPCharType::canConvertToJava(HostRef* obj)
 			return _exact;
 		}
 	}
-
-
 
 	return _none;
 }

--- a/native/common/jp_typemanager.cpp
+++ b/native/common/jp_typemanager.cpp
@@ -77,6 +77,9 @@ JPClass* findClass(const JPTypeName& name)
 
 	// No we havent got it .. lets load it!!!
 	JPCleaner cleaner;
+	if (JPEnv::getJava()==0)
+		return 0;
+
 	jclass cls = JPEnv::getJava()->FindClass(name.getNativeName().c_str());
 	cleaner.addLocal(cls);
 

--- a/test/harness/jpype/boxed/Boxed.java
+++ b/test/harness/jpype/boxed/Boxed.java
@@ -1,0 +1,38 @@
+package jpype.boxed;
+
+public class Boxed
+{ 
+  // Call each type
+  static public boolean callBoolean(boolean i) { return i; }
+  static public byte    callByte(byte i)       { return i; }
+  static public char    callChar(char i)       { return i; }
+  static public short   callShort(short i)     { return i; }
+  static public int     callInteger(int i)     { return i; }
+  static public long    callLong(long i)       { return i; }
+  static public float   callFloat(float i)     { return i; }
+  static public double  callDouble(double i)   { return i; }
+
+  // Create a boxed type
+  static public Short newShort(short i) { return i; }
+  static public Integer newInteger(int i) { return i; }
+  static public Long newLong(long i) { return i; }
+  static public Float newFloat(float i) { return i; }
+  static public Double newDouble(double i) { return i; }
+
+  // Check which is called
+  static public int whichShort(short i) { return 1; }
+  static public int whichShort(Short i) { return 2; }
+
+  static public int whichInteger(int i) { return 1; }
+  static public int whichInteger(Integer i) { return 2; }
+
+  static public int whichLong(long i) { return 1; }
+  static public int whichLong(Long i) { return 2; }
+
+  static public int whichFloat(float i) { return 1; }
+  static public int whichFloat(Float i) { return 2; }
+
+  static public int whichDouble(double i) { return 1; }
+  static public int whichDouble(Double i) { return 2; }
+}
+

--- a/test/jpypetest/boxed.py
+++ b/test/jpypetest/boxed.py
@@ -1,0 +1,155 @@
+#*****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#*****************************************************************************
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import sys
+import jpype
+import jpype._jboxed
+from . import common
+
+#Python2/3 support
+if sys.version > '3':
+    long  =  int
+    unicode = str
+
+# Test code
+class BoxedTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+        self.Boxed = jpype.JClass('jpype.boxed.Boxed')
+        self.Object = jpype.JClass('java.lang.Object')
+        self.Number = jpype.JClass('java.lang.Number')
+        self.Comparable = jpype.JClass('java.lang.Comparable')
+        self.Short = jpype.JClass('java.lang.Short')
+        self.Integer = jpype.JClass('java.lang.Integer')
+        self.Long = jpype.JClass('java.lang.Long')
+        self.Float = jpype.JClass('java.lang.Float')
+        self.Double = jpype.JClass('java.lang.Double')
+
+    def testShort(self):
+        c1=12345
+        # Check passed from and passed to
+        d1=self.Boxed.newShort(c1)
+        d2=self.Short(c1)
+        self.assertEqual(d1,c1)
+        self.assertEqual(d2,c1)
+        self.assertEqual(d1,d2)
+        self.assertEqual(self.Boxed.callShort(c1), self.Boxed.callShort(d2))
+        # Verify ops
+        self.assertEqual(d1+2,d1+2)
+        self.assertEqual(d1*2,d1*2)
+
+    def testInteger(self):
+        c1=12345
+        # Check passed from and passed to
+        d1=self.Boxed.newInteger(c1)
+        d2=self.Integer(c1)
+        self.assertEqual(d1,c1)
+        self.assertEqual(d2,c1)
+        self.assertEqual(d1,d2)
+        self.assertEqual(self.Boxed.callInteger(c1), self.Boxed.callInteger(d2))
+        # Verify ops
+        self.assertEqual(d1+2,d1+2)
+        self.assertEqual(d1*2,d1*2)
+
+    def testLong(self):
+        c1=12345
+        # Check passed from and passed to
+        d1=self.Boxed.newLong(c1)
+        d2=self.Long(c1)
+        self.assertEqual(d1,c1)
+        self.assertEqual(d2,c1)
+        self.assertEqual(d1,d2)
+        self.assertEqual(self.Boxed.callLong(c1), self.Boxed.callLong(d2))
+        # Verify ops
+        self.assertEqual(d1+2,d1+2)
+        self.assertEqual(d1*2,d1*2)
+
+    def testDoubleFromFloat(self):
+        self.Double(1.0)
+
+    def testFloatFromInt(self):
+        self.Float(1)
+
+    def testDoubleFromInt(self):
+        self.Double(1)
+
+    def testBoxed2(self):
+        self.Short(self.Integer(1))
+        self.Integer(self.Integer(1))
+        self.Long(self.Integer(1))
+        self.Float(self.Integer(1))
+        self.Float(self.Long(1))
+        self.Double(self.Integer(1))
+        self.Double(self.Long(1))
+        self.Double(self.Float(1))
+
+    def testFloat(self):
+        c1=123124/256.0
+        # Check passed from and passed to
+        d1=self.Boxed.newFloat(c1)
+        d2=self.Float(c1)
+        self.assertEqual(d1,c1)
+        self.assertEqual(d2,c1)
+        self.assertEqual(d1,d2)
+        self.assertEqual(self.Boxed.callFloat(c1), self.Boxed.callFloat(d2))
+        # Verify ops
+        self.assertEqual(d1+2,d1+2)
+        self.assertEqual(d1*2,d1*2)
+        self.assertTrue(d2<c1+1)
+        self.assertTrue(d2>c1-1)
+
+    def testDouble(self):
+        c1=123124/256.0
+        # Check passed from and passed to
+        d1=self.Boxed.newDouble(c1)
+        d2=self.Double(c1)
+        self.assertEqual(d1,c1)
+        self.assertEqual(d2,c1)
+        self.assertEqual(d1,d2)
+        self.assertEqual(self.Boxed.callDouble(c1), self.Boxed.callDouble(d2))
+        # Verify ops
+        self.assertEqual(d1+2,d1+2)
+        self.assertEqual(d1*2,d1*2)
+        self.assertTrue(d2<c1+1)
+        self.assertTrue(d2>c1-1)
+
+    def testShortResolve(self):
+        self.assertEqual(self.Boxed.whichShort(1), 1)
+        self.assertEqual(self.Boxed.whichShort(self.Short(1)), 2)
+
+    def testIntegerResolve(self):
+        self.assertEqual(self.Boxed.whichInteger(1), 1)
+        self.assertEqual(self.Boxed.whichInteger(self.Integer(1)), 2)
+
+    def testLongResolve(self):
+        self.assertEqual(self.Boxed.whichLong(1), 1)
+        self.assertEqual(self.Boxed.whichLong(self.Long(1)), 2)
+ 
+    def testFloatResolve(self):
+        self.assertEqual(self.Boxed.whichFloat(1.0), 1)
+        self.assertEqual(self.Boxed.whichFloat(self.Float(1.0)), 2)
+
+    def testDoubleResolve(self):
+        self.assertEqual(self.Boxed.whichDouble(1.0), 1)
+        self.assertEqual(self.Boxed.whichDouble(self.Double(1.0)), 2)
+
+if __name__=='__main__':
+    jpype.startJVM(jpype.getDefaultJVMPath())
+    unittest.main()

--- a/test/jpypetest/numeric.py
+++ b/test/jpypetest/numeric.py
@@ -76,7 +76,7 @@ class NumericTestCase(common.JPypeTestCase):
         jwrapper(float(2**127))
         javawrapper(float(2**127))
         self.assertRaises(TypeError, jwrapper, float(2**128))
-        self.assertRaisesRegexp(RuntimeError, 'No matching overloads found', javawrapper, 5) # no conversion from int?
+        #self.assertRaisesRegexp(RuntimeError, 'No matching overloads found', javawrapper, 5) # no conversion from int?
 
         # this difference might be undesirable, 
         # a double bigger than maxfloat passed to java.lang.Float turns into infinity 


### PR DESCRIPTION
- Convert boxed types to python types automatically.   Uses type hacking to make boxed types inherit from python types.  Has some major changes to implicit rules so may have some edge cases.
- Minor patch to split MTRACE and TRACE so that can used diff between python2 and python3 to resolve differences in type resolution.  
- Does not replace _JWrapper.   
- Breaks one test case by allowing java.lang.Float(1) and java.lang.Double(1) to succeed.
- Exports JavaObject and JavaClass as stub types for use with isinstance().