### PR TITLE
Bulletproof

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ sudo: false
 addons:
   apt:
     packages:
+    - oracle-java8-installer
     - ant
+
 env:
   # one build with and without numpy support (opt numpy out)
   - NUMPY="--install-option=--disable-numpy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,13 @@ python:
   #dist: trusty
 sudo: false
 
+jdk:
+  - oraclejdk8
+
 addons:
   apt:
     packages:
-    - oracle-java8-installer
+    - oracle-java8-set-default
     - ant
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ python:
   - 'pypy3'
   - "nightly"
 
+dist: trusty
 sudo: false
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ python:
   - "nightly"
 
   #dist: trusty
-sudo: false
+sudo: required
 
 jdk:
   - oraclejdk8
@@ -52,5 +52,6 @@ install:
   - ant -f test/build.xml
 
 script:
+  - jdk_switcher use oraclejdk8
   - python -c "import jpype"
   - python test/testsuite.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,12 @@ matrix:
       env: NUMPY="--install-option=--disable-numpy"
 
 install:
+  - ls /usr/lib/jvm/
+  - update-java-alternatives -l
   - pip install . $NUMPY
   - pip install -r test-requirements.txt
   - ant -f test/build.xml
 
 script:
-  - jdk_switcher use oraclejdk8
   - python -c "import jpype"
   - python test/testsuite.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,6 @@ python:
   - 'pypy3'
   - "nightly"
 
-    #dist: trusty
-sudo: required
-
-jdk:
-  - oraclejdk8
-
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
   - 'pypy3'
   - "nightly"
 
-  #dist: trusty
+    #dist: trusty
 sudo: required
 
 jdk:
@@ -23,7 +23,6 @@ jdk:
 addons:
   apt:
     packages:
-    - oracle-java8-set-default
     - ant
 
 env:
@@ -46,9 +45,6 @@ matrix:
     - python: 'nightly'
       env: NUMPY="--install-option=--disable-numpy"
   
-before_install:    
-  - sudo update-java-alternatives -s java-8-oracle
-
 install:
   - pip install . $NUMPY
   - pip install -r test-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
   - 'pypy3'
   - "nightly"
 
-dist: trusty
+  #dist: trusty
 sudo: false
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,11 @@ matrix:
       env: NUMPY=""
     - python: 'nightly'
       env: NUMPY="--install-option=--disable-numpy"
+  
+before_install:    
+  - sudo update-java-alternatives -s java-8-oracle
 
 install:
-  - ls /usr/lib/jvm/
-  - update-java-alternatives -l
   - pip install . $NUMPY
   - pip install -r test-requirements.txt
   - ant -f test/build.xml

--- a/native/python/jpype_javaarray.cpp
+++ b/native/python/jpype_javaarray.cpp
@@ -31,10 +31,10 @@ namespace { // impl detail
 PyObject* JPypeJavaArray::findArrayClass(PyObject* obj, PyObject* args)
 {
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		char* cname;

--- a/native/python/jpype_javaarray.cpp
+++ b/native/python/jpype_javaarray.cpp
@@ -30,6 +30,12 @@ namespace { // impl detail
 
 PyObject* JPypeJavaArray::findArrayClass(PyObject* obj, PyObject* args)
 {
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		char* cname;
 		JPyArg::parseTuple(args, "s", &cname);

--- a/native/python/jpype_javaclass.cpp
+++ b/native/python/jpype_javaclass.cpp
@@ -70,10 +70,10 @@ PyObject* JPypeJavaClass::findClass(PyObject* obj, PyObject* args)
 {
 	TRACE_IN("JPypeModule::findClass");
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		char* cname;

--- a/native/python/jpype_javaclass.cpp
+++ b/native/python/jpype_javaclass.cpp
@@ -69,6 +69,12 @@ PyObject* JPypeJavaClass::setSpecialConstructorKey(PyObject* self, PyObject* arg
 PyObject* JPypeJavaClass::findClass(PyObject* obj, PyObject* args)
 {
 	TRACE_IN("JPypeModule::findClass");
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		char* cname;
 		JPyArg::parseTuple(args, "s", &cname);

--- a/native/python/jpype_javanio.cpp
+++ b/native/python/jpype_javanio.cpp
@@ -18,6 +18,12 @@
 #include <jpype_python.h>  
 PyObject* JPypeJavaNio::convertToDirectBuffer(PyObject* self, PyObject* args)
 {  
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	TRACE_IN("convertStringToBuffer"); 
 
 	// Use special method defined on the TypeConverter interface ...

--- a/native/python/jpype_javanio.cpp
+++ b/native/python/jpype_javanio.cpp
@@ -19,10 +19,10 @@
 PyObject* JPypeJavaNio::convertToDirectBuffer(PyObject* self, PyObject* args)
 {  
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	TRACE_IN("convertStringToBuffer"); 
 

--- a/native/python/jpype_module.cpp
+++ b/native/python/jpype_module.cpp
@@ -19,6 +19,12 @@
 PyObject* JPypeModule::startup(PyObject* obj, PyObject* args)  
 {  
 	TRACE_IN("startup");
+	if (JPEnv::isInitialized())
+	{
+		PyErr_SetString(PyExc_OSError, "JVM is already started");
+		return NULL;
+  }
+
 	try {
 		PyObject* vmOpt;
 		PyObject* vmPath;
@@ -72,6 +78,12 @@ PyObject* JPypeModule::startup(PyObject* obj, PyObject* args)
 PyObject* JPypeModule::attach(PyObject* obj, PyObject* args)  
 {  
 	TRACE_IN("attach");
+  if (JPEnv::isInitialized())
+	{
+		PyErr_SetString(PyExc_OSError, "JVM is already started");
+		return NULL;
+  }
+
 	try {
 		PyObject* vmPath;
 

--- a/native/python/jpype_module.cpp
+++ b/native/python/jpype_module.cpp
@@ -208,10 +208,10 @@ PyObject* JPypeModule::isStarted(PyObject* obj)
 PyObject* JPypeModule::attachThread(PyObject* obj)
 {
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		JPEnv::attachCurrentThread();
@@ -226,10 +226,10 @@ PyObject* JPypeModule::attachThread(PyObject* obj)
 PyObject* JPypeModule::detachThread(PyObject* obj)
 {
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		JPEnv::getJava()->DetachCurrentThread();
@@ -244,10 +244,10 @@ PyObject* JPypeModule::detachThread(PyObject* obj)
 PyObject* JPypeModule::isThreadAttached(PyObject* obj)
 {	
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		if (JPEnv::isThreadAttached())
@@ -304,10 +304,10 @@ PyObject* JPypeModule::raiseJava(PyObject* , PyObject* args)
 PyObject* JPypeModule::attachThreadAsDaemon(PyObject* obj)
 {
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		JPEnv::attachCurrentThreadAsDaemon();
@@ -324,10 +324,10 @@ PyObject* JPypeModule::attachThreadAsDaemon(PyObject* obj)
 PyObject* JPypeModule::startReferenceQueue(PyObject* obj, PyObject* args)
 {
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		int i;
@@ -346,10 +346,10 @@ PyObject* JPypeModule::startReferenceQueue(PyObject* obj, PyObject* args)
 PyObject* JPypeModule::stopReferenceQueue(PyObject* obj)
 {
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		JPJni::stopJPypeReferenceQueue();
@@ -366,10 +366,10 @@ PyObject* JPypeModule::stopReferenceQueue(PyObject* obj)
 PyObject* JPypeModule::setConvertStringObjects(PyObject* obj, PyObject* args)
 {
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		PyObject* flag;

--- a/native/python/jpype_module.cpp
+++ b/native/python/jpype_module.cpp
@@ -207,6 +207,12 @@ PyObject* JPypeModule::isStarted(PyObject* obj)
 
 PyObject* JPypeModule::attachThread(PyObject* obj)
 {
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		JPEnv::attachCurrentThread();
 		Py_INCREF(Py_None);
@@ -219,6 +225,12 @@ PyObject* JPypeModule::attachThread(PyObject* obj)
 
 PyObject* JPypeModule::detachThread(PyObject* obj)
 {
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		JPEnv::getJava()->DetachCurrentThread();
 		Py_INCREF(Py_None);
@@ -230,7 +242,13 @@ PyObject* JPypeModule::detachThread(PyObject* obj)
 }
 
 PyObject* JPypeModule::isThreadAttached(PyObject* obj)
-{
+{	
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		if (JPEnv::isThreadAttached())
 	{
@@ -285,6 +303,12 @@ PyObject* JPypeModule::raiseJava(PyObject* , PyObject* args)
 
 PyObject* JPypeModule::attachThreadAsDaemon(PyObject* obj)
 {
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		JPEnv::attachCurrentThreadAsDaemon();
 
@@ -299,6 +323,12 @@ PyObject* JPypeModule::attachThreadAsDaemon(PyObject* obj)
 
 PyObject* JPypeModule::startReferenceQueue(PyObject* obj, PyObject* args)
 {
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		int i;
 		JPyArg::parseTuple(args, "i", &i);
@@ -315,6 +345,12 @@ PyObject* JPypeModule::startReferenceQueue(PyObject* obj, PyObject* args)
 
 PyObject* JPypeModule::stopReferenceQueue(PyObject* obj)
 {
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		JPJni::stopJPypeReferenceQueue();
 
@@ -329,6 +365,12 @@ PyObject* JPypeModule::stopReferenceQueue(PyObject* obj)
 
 PyObject* JPypeModule::setConvertStringObjects(PyObject* obj, PyObject* args)
 {
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		PyObject* flag;
 		JPyArg::parseTuple(args, "O", &flag);

--- a/native/python/jpype_python.cpp
+++ b/native/python/jpype_python.cpp
@@ -73,6 +73,12 @@ PyObject* JPypeJavaProxy::setProxyClass(PyObject* self, PyObject* arg)
 
 PyObject* convertToJValue(PyObject* self, PyObject* arg)
 {
+	if (! JPEnv::isInitialized())
+  {
+		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
+		return NULL;
+  }
+
 	try {
 		char* tname;
 		PyObject* value;

--- a/native/python/jpype_python.cpp
+++ b/native/python/jpype_python.cpp
@@ -74,10 +74,10 @@ PyObject* JPypeJavaProxy::setProxyClass(PyObject* self, PyObject* arg)
 PyObject* convertToJValue(PyObject* self, PyObject* arg)
 {
 	if (! JPEnv::isInitialized())
-  {
+	{
 		PyErr_SetString(PyExc_RuntimeError, "Java Subsystem not started");
 		return NULL;
-  }
+	}
 
 	try {
 		char* tname;

--- a/native/python/pythonenv.cpp
+++ b/native/python/pythonenv.cpp
@@ -314,12 +314,14 @@ double JPyFloat::asDouble(PyObject* obj)
 
 PyObject* JPyBoolean::getTrue()
 {
-	return PyInt_FromLong(1);
+	Py_RETURN_TRUE;
+//	return PyInt_FromLong(1);
 }
 
 PyObject* JPyBoolean::getFalse()
 {
-	return PyInt_FromLong(0);
+	Py_RETURN_FALSE;
+//	return PyInt_FromLong(0);
 }
 
 bool JPyDict::contains(PyObject* m, PyObject* k)

--- a/test/bulletproof.py
+++ b/test/bulletproof.py
@@ -1,0 +1,61 @@
+import unittest
+import jpype
+import _jpype
+
+class TestJpypeModule(unittest.TestCase):
+    def setUp(self):
+        self.methods={
+           'attach': [tuple(["none"]),RuntimeError],
+           'attachThreadAsDaemon': [tuple(),RuntimeError],
+           'attachThreadToJVM': [tuple(), RuntimeError],
+           'convertToDirectBuffer': [tuple(), RuntimeError],
+           'convertToJValue': [tuple(["a",1]), RuntimeError],
+           'createProxy': [tuple(['a',(1,2)]), AttributeError],
+           'detachThreadFromJVM': [tuple(), RuntimeError],
+           'dumpJVMStats': [tuple(), None],
+           'findArrayClass': [tuple('double[]'), RuntimeError],
+           'findClass': [tuple('java.lang.String'), RuntimeError],
+           'getArrayItem': [tuple([None,1]), TypeError],
+           'getArrayLength': [tuple([None]), TypeError],
+           'getArraySlice': [tuple([None,1,2]), TypeError],
+           'isStarted': [tuple(), None],
+           'isThreadAttachedToJVM': [tuple(), RuntimeError],
+           'newArray': [tuple([None,1]), TypeError],
+           'setArrayItem': [tuple([None,1,2]), TypeError],
+           'setArraySlice': [tuple([None,1,2,3]), TypeError],
+           'setConvertStringObjects': [tuple(), RuntimeError],
+           'setGetClassMethod': [tuple([None]), None],
+           'setGetJavaArrayClassMethod': [tuple([None]), None],
+           'setJavaArrayClass': [tuple([None]), None],
+           'setJavaExceptionClass': [tuple([None]), None],
+           'setJavaLangObjectClass': [tuple([None]), None],
+           'setProxyClass': [tuple([None]), None],
+           'setSpecialConstructorKey': [tuple([None]), None],
+           'setStringWrapperClass': [tuple([None]), None],
+           'setWrapperClass': [tuple([None]), None],
+           'shutdown': [tuple(), RuntimeError],
+           'startReferenceQueue': [tuple([1]), RuntimeError],
+           'startup': [tuple([None,tuple([None]),None]), TypeError],
+           'stopReferenceQueue': [tuple(), RuntimeError],
+           'synchronized': [tuple(), None],
+           }
+
+    def testEntryPoints(self):
+        for n,c in self.methods.items():
+            print('====',n)
+            method=getattr(_jpype, n)
+            args=c[0]
+            expect=c[1]
+            if expect==None:
+                method(*args)
+                print("PASS: %s => None "%n)
+            else:
+                self.assertRaises(expect, method, *args)
+
+
+# This is a special test suite that checks to see that every entry point to the private
+# module will safely fail rather than segfaulting.  It can't be run with other tests
+# as the jvm must not be loaded.
+#
+# To test use
+#   nosetests test.bulletproof

--- a/test/bulletproof.py
+++ b/test/bulletproof.py
@@ -48,7 +48,7 @@ class TestJpypeModule(unittest.TestCase):
             expect=c[1]
             if expect==None:
                 method(*args)
-                print("PASS: %s => None "%n)
+                #print("PASS: %s => None "%n)
             else:
                 self.assertRaises(expect, method, *args)
 

--- a/test/jpypetest/startup.py
+++ b/test/jpypetest/startup.py
@@ -1,0 +1,39 @@
+#*****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#*****************************************************************************
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import sys
+import jpype
+from . import common
+
+class StartJVMCase(common.JPypeTestCase):
+
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+
+    def testStartup(self):
+        # Test that we are robust to multiple startJVM
+        try:
+            self.assertRaises(OSError, jpype.startJVM, jpype.getDefaultJVMPath())
+            self.assertRaises(OSError, jpype.startJVM, jpype.getDefaultJVMPath())
+        except RuntimeError:
+            pass 
+        # Verify that we don't crash after repeat
+        jpype.JClass("java.lang.String")
+


### PR DESCRIPTION
This patch deals with segfaults that can happen if a jpype call is made prior to starting the JVM.   Each entry point was tested to see if it properly issues a RuntimeError if that entry point could have produced a segfault.  Test bench for verifying was added, but as it must not be run with the other tests we may need to improve the runTestSuite to handle more than one test set.  

Also contains a minor patch for Boolean types as there were cases of accidental promotion which would be incorrect for a strongly typed language such as Java.  

Like the other patches this is an independent patch.  