### PR TITLE
Array enhancements

### DIFF
--- a/jpype/_jarray.py
+++ b/jpype/_jarray.py
@@ -127,6 +127,7 @@ def _defineArrayClass(name, jt):
     members = {
             "__init__": _jarrayInit,
             "__javaclass__": jt,
+            "__name__": name,
     }
 
     bases = [_JavaArrayClass]

--- a/jpype/_jwrapper.py
+++ b/jpype/_jwrapper.py
@@ -93,6 +93,7 @@ def _getDefaultTypeName(obj):
         "Unable to determine the default type of {0}".format(obj.__class__))
 
 class JObject(_JWrapper):
+    typeName="java.lang.Object"
     def __init__(self, v, tp=None):
         if tp is None:
             tp = _getDefaultTypeName(v)


### PR DESCRIPTION
Support to make `__name__` more consistent.

```python
>>> java.lang.String.__name__
'java.lang.String'
>>> java.lang.String().__name__
'java.lang.String'
>>> JArray(JInt,1).__name__
'int[]'
>>> JArray(JInt,1)(1).__name__
'int[]'
```

And add support for JObject as a JArray argument.
```python
>>> JArray(JObject,1)
<class 'jpype._jarray.java.lang.Object[]'>
```
