### PR TITLE
Closed behavior for objects and arrays.

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 This changelog *only* contains changes from the *first* pypi release (0.5.4.3) onwards.
 
 - **Next version - unreleased**
+
+  - Java objects and arrays will not accept setattr unless the 
+    attribute corresponds to a java method or field whith 
+    the exception of private attributes that begin with 
+    underscore.
+
 - **0.6.2 - 2017-01-13**
 
   - Fix JVM location for OSX.

--- a/jpype/_jarray.py
+++ b/jpype/_jarray.py
@@ -82,6 +82,15 @@ class _JavaArrayClass(object):
             j = _jpype.getArrayLength(self.__javaobject__)
         _jpype.setArraySlice(self.__javaobject__, i, j, v)
 
+    def __setattr__(self, attr, value):
+        if attr.startswith('_') \
+               or callable(value) \
+               or isinstance(getattr(self.__class__, attr), property):
+            object.__setattr__(self, attr, value)
+        else:
+            raise AttributeError("%s does not have field %s"%(self.__name__, attr), self)
+
+
 def _jarrayInit(self, *args):
     if len(args) == 2 and args[0] == _jclass._SPECIAL_CONSTRUCTOR_KEY:
         _JavaArrayClass.__init__(self, args[1])

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -99,6 +99,14 @@ def _javaGetAttr(self, name):
         return _jpype._JavaBoundMethod(r, self)
     return r
 
+def _javaSetAttr(self, attr, value):
+    if attr.startswith('_') \
+           or callable(value) \
+           or isinstance(getattr(self.__class__, attr), property):
+        object.__setattr__(self, attr, value)
+    else:
+        raise AttributeError("%s does not have field %s"%(self.__name__, attr), self)
+
 def _mro_override_topsort(cls):
     # here we run a topological sort to get a linear ordering of the inheritance graph.
     parents = set().union(*[x.__mro__ for x in cls.__bases__])
@@ -135,6 +143,7 @@ class _JavaClass(type):
                 "__eq__": lambda self, o: self.equals(o),
                 "__ne__": lambda self, o: not self.equals(o),
                 "__getattribute__": _javaGetAttr,
+                "__setattr__": _javaSetAttr,
                 }
 
         if name == 'java.lang.Object' or jc.isPrimitive():

--- a/test/harness/jpype/objectwrapper/Static.java
+++ b/test/harness/jpype/objectwrapper/Static.java
@@ -1,0 +1,8 @@
+package jpype.objectwrapper;
+
+class StaticTest
+{
+	public static int i=1;
+	public static double d=1.2345;
+	public static String s="hello";
+}

--- a/test/jpypetest/closed.py
+++ b/test/jpypetest/closed.py
@@ -1,0 +1,40 @@
+import unittest
+import jpype
+from . import common
+
+#jpype.startJVM(jpype.getDefaultJVMPath())
+
+class ClosedTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+
+    def testObjects(self):
+        from jpype import java
+
+        s=java.lang.String('foo')
+        s._allowed = 1
+        try:
+            s.forbidden = 1
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError("AttributeError not raised")
+
+    def testArrays(self):
+        s=jpype.JArray(jpype.JInt)(5)
+        # Setting private members is allowed
+        s._allowed = 1
+        try:
+            # Setting public members is prohibited
+            s.forbidden = 1
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError("AttributeError not raised")
+
+    def testStatic(self):
+        static=jpype.JClass('jpype.objectwrapper.StaticTest')
+        self.assertEquals(static.i, 1)
+        self.assertEquals(static.d, 1.2345)
+        self.assertEquals(static.s, "hello")
+


### PR DESCRIPTION
In order to reduce the problems with typos and moved members, I recommend overriding the `__setattr__` on classes and objects.  The change still allows unrestricted access to set methods and private variables that begin with underscore, but will issue `AttributeError` if other members are set.   This prevents a major source of errors while still allowing augmentation of java objects for frameworks.

This patch is independent of all others submitted.