### PR TITLE
Patch to fix Class.forName()

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,10 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 - **Next version - unreleased**
 
+  - java.lang.Class<>.forName() will now return the java.lang.Class.  
+    Work arounds for requiring the class loader are no longer needed.
+    Customizers now support customization of static members.
+
   - Support of java.lang.Class<> 
     - java.lang.Object().getClass() on Java objects returns a java.lang.Class 
       rather than the Python class

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -462,14 +462,6 @@ API does not provide methods to simulate one.
 At the moment, the methods known to fail are :
 
 
-java.lang.Class.forName(String classname)
-:::::::::::::::::::::::::::::::::::::::::
-
-This method relies on the current class's classloader to do its loading. It
-can easily be replaced with **Class.forName(classname, True,
-ClassLoader.getSystemClassLoader())**.
-
-
 java.sql.DriverManager.getConnection(...)
 :::::::::::::::::::::::::::::::::::::::::
 

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -37,6 +37,7 @@ _COMPARABLE_METHODS = {
 
 def _initialize():
     global _COMPARABLE, _JAVACLASS, _JAVAOBJECT, _JAVATHROWABLE, _RUNTIMEEXCEPTION
+    registerClassCustomizer(_JavaLangClassCustomizer())
 
     _JAVAOBJECT = JClass("java.lang.Object")
     _JAVACLASS = JClass("java.lang.Class")
@@ -46,7 +47,6 @@ def _initialize():
     _jpype.setResource('JavaObject', _JavaObject)
     _jpype.setResource('GetClassMethod',_getClassFor)
     _jpype.setResource('SpecialConstructorKey',_SPECIAL_CONSTRUCTOR_KEY)
-    registerClassCustomizer(_JavaLangClassCustomizer())
 
 
 def registerClassCustomizer(c):

--- a/test/jpypetest/forname.py
+++ b/test/jpypetest/forname.py
@@ -1,0 +1,32 @@
+#*****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#*****************************************************************************
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import sys
+import jpype
+from . import common
+
+class ForNameTestCase(common.JPypeTestCase):
+
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+
+    def testForName(self):
+        cls=jpype.JClass('java.lang.Class')
+        cls.forName('jpype.overloads.Test1')

--- a/test/jpypetest/forname.py
+++ b/test/jpypetest/forname.py
@@ -29,4 +29,7 @@ class ForNameTestCase(common.JPypeTestCase):
 
     def testForName(self):
         cls=jpype.JClass('java.lang.Class')
-        cls.forName('jpype.overloads.Test1')
+        test=cls.forName('jpype.overloads.Test1')
+        # Should return a java.lang.Class, rather than the python wrapper for java.lang.Class
+        self.assertTrue( type(test)==type(cls.class_))
+        self.assertEquals( test.getName(), 'jpype.overloads.Test1')


### PR DESCRIPTION
This was a fairly difficult modification as customizers do not support changing fields.  I introduced an enhanced customizer as best I could.  This allows direct adjustment of fields.   This addresses the defective forName()