### PR TITLE
Cygwin + Appveyor (final?)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.py[cod]
 # C extensions
 *.so
+*.dll
 # Distribution / packaging
 .Python
 env/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,49 +4,85 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
-    ANT_HOME: C:\ant
+    ANT_HOME: "C:\\ProgramData\\chocolatey\\lib\\ant\\apache-ant-1.10.1"
+    NUMPY_: "numpy x.x"
 
   matrix:
+    - PYTHON: "python3"
+      CYGWIN: "C:\\cygwin"
+      JAVA_HOME: "C:\\Program Files (x86)\\Java\\jdk1.8.0"
+      ARCH: x86 
+      CYGSH: C:\Cygwin\bin\bash -c
+
+    - PYTHON: "python2"
+      CYGWIN: "C:\\cygwin64"
+      JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
+      ARCH: x86_64 
+      CYGSH: C:\Cygwin64\bin\bash -c
+
+    - PYTHON: "python3"
+      CYGWIN: "C:\\cygwin64"
+      JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
+      ARCH: x86_64 
+      CYGSH: C:\Cygwin64\bin\bash -c
+
     - PYTHON: "C:\\Miniconda"
+      CONDA_PY: "2.7"
       JAVA_HOME: "C:\\Program Files (x86)\\Java\\jdk1.8.0"
 
     - PYTHON: "C:\\Miniconda-x64"
+      CONDA_PY: "2.7"
       JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
+      ARCH: "64"
 
     - PYTHON: "C:\\Miniconda3"
+      CONDA_PY: "3.5"
       JAVA_HOME: "C:\\Program Files (x86)\\Java\\jdk1.8.0"
 
     - PYTHON: "C:\\Miniconda3-x64"
+      CONDA_PY: "3.6"
       JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
+      ARCH: "64"
+
+    - PYTHON: "C:\\Miniconda3-x64"
+      CONDA_PY: "3.6"
+      JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
+      ARCH: "64"
+      NUMPY_: "python"
+
+    ## This one is failing from gcc died with sig 11.  
+    ## This error is apparently common when building python 2 modules with cygwin32.
+    ## The failure depends on the windows version and will cause a failure 
+    ## on appveyor depending on which image is used.
+    ## We will disable it for now
+    #
+    # - PYTHON: "python2"
+    #  CYGWIN: "C:\\cygwin"
+    #  JAVA_HOME: "C:\\Program Files (x86)\\Java\\jdk1.8.0"
+    #  ARCH: x86 
+    #  CYGSH: C:\Cygwin\bin\bash -c
 
 install:
-  # Install Python (from the official .msi of http://python.org) and pip when
-  # not already installed.
-  - "powershell ./appveyor/install.ps1"
+  - cinst ant
 
-  # Prepend newly installed Python to the PATH of this build (this cannot be
-  # done from inside the powershell script as it would require to restart
-  # the parent CMD process).
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;C:\\ant\\bin;%PATH%"
+  # Add thinges to path 
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%ANT_HOME%\\bin;%PATH%"
 
-  # Check that we have the expected version and architecture for Python
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  # If cygwin installed run install.sh, else run the install.ps1
+  - "IF DEFINED CYGWIN (%CYGSH% appveyor/install.sh) ELSE (powershell ./appveyor/install.ps1)"
 
-  # Install the build dependencies of the project. If some dependencies contain
-  # compiled extensions and are not provided as pre-built wheel packages,
-  # pip will build them from source using the MSVC compiler matching the
-  # target Python version and architecture
-  - "conda update --all -y"
-  - "conda install nose setuptools -y"
-  - "pip install -r test-requirements.txt" # -r dev-requirements.txt
-
-  - "ant -f test\\build.xml"
-  # Build the compiled extension and run the project tests
-  - "python setup.py install"
 build: false # Not a C# project, build stuff at the test step instead.
 
 test_script:
+  #- "%CMD_IN_ENV% conda build devtools\\conda-recipe --numpy=112"
   # run testsuite and upload test results to AppVeyor; return exit code of testsuite
-  - "powershell ./appveyor/runTestsuite.ps1"
+  - "IF DEFINED CYGWIN (%CYGSH% appveyor/runTestSuite.sh) ELSE (powershell ./appveyor/runTestSuite.ps1)"
 
+on_finish:
+  # upload results to AppVeyor
+  - "powershell ./appveyor/upload.ps1"
+
+#  - ps: $wc = New-Object 'System.Net.WebClient'; $wc.UploadFile('https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)', (Resolve-Path .\xunit.xml))
+#
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,89 +1,18 @@
-# install apache ant
-$ANT_VERSION = "1.10.1"
+# Check that we have the expected version and architecture for Python
+ant.exe -version
+python.exe --version
+python.exe -c "import struct; print(struct.calcsize('P') * 8)"
 
-function RunCommand ($command, $command_args) {
-    Write-Host $command $command_args
-    Start-Process -FilePath $command -ArgumentList $command_args -Wait -Passthru
-}
+# Install the build dependencies of the project. If some dependencies contain
+# compiled extensions and are not provided as pre-built wheel packages,
+# pip will build them from source using the MSVC compiler matching the
+# target Python version and architecture
+conda.exe update --all -y 
+conda.exe install nose setuptools -y
+pip.exe install -r "test-requirements.txt" # -r dev-requirements.txt
 
-function unzipAnt($file, $destination) {
-    if (-Not (Test-Path $file)) {
-        Write-Host "File " $file "does not exist!"
-        return
-    }
-    
-    if (-Not (Test-Path $destination)) {
-        mkdir $destination
-    }
+ant.exe -f test\\build.xml
 
-    Write-Host "extract " $file " to " $destination
-    $shell_app = new-object -com shell.application
-    $zip_file = $shell_app.namespace($file)
-    $dir = $shell_app.namespace($destination)
-    $dir.Copyhere($zip_file.items())
+# Build the compiled extension and run the project tests
+python.exe setup.py install
 
-    # this should return the only folder name contained in ant.zip
-    #$foldername = ""
-    $zip_file.items() | foreach {
-        $foldername = $_.name
-        Write-Host "current foldername" $foldername
-    }
-    return $foldername
-}
-
-function DownloadAnt() {
-    $url = "http://www.us.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.zip"
-    $webclient = New-Object System.Net.WebClient
-    $filepath = "C:\ant.zip"
-	
-	if (Test-Path $filepath) {
-        Write-Host "Reusing" $filepath
-        return $filepath
-    }
-	
-    # Download and retry up to 3 times in case of network transient errors.
-    Write-Host "Downloading" $filename "from" $url
-    $retry_attempts = 2
-    for($i=0; $i -lt $retry_attempts; $i++){
-        try {
-            $webclient.DownloadFile($url, $filepath)
-            break
-        }
-        Catch [Exception]{
-            Start-Sleep 1
-        }
-   }
-   if (Test-Path $filepath) {
-       Write-Host "File saved at" $filepath
-   } else {
-       # Retry once to get the error message if any at the last try
-       $webclient.DownloadFile($url, $filepath)
-   }
-   return $filepath
-}
-
-function InstallAnt() {
-    if (Test-Path "c:\apache-ant-$ANT_VERSION") {
-        Write-Host "ant already exists"
-        return $false
-    }
-
-    $filepath = DownloadAnt
-    # extract to C: (will result in something like C:\apache-ant-1.9.4
-    $folder = unzipAnt $filepath "C:"
-    
-    $ant_path  = "C:\apache-ant-$ANT_VERSION\bin"
-    
-    if (-not (Test-Path $ant_path)) {
-        Throw "unpacked folder '" + $ant_path + "' does not exist!"
-    }
-
-    # create link to default ant binary dir, so we can rely on it.
-    cmd.exe /c mklink /d C:\ant $folder
-}
-
-function main () {
-    InstallAnt
-}
-
-main

--- a/appveyor/install.sh
+++ b/appveyor/install.sh
@@ -1,0 +1,48 @@
+# Setup cygwin path
+
+export PATH="$ANT_BIN/bin:/bin:/usr/bin"
+
+echo ARCH=$ARCH
+echo PATH=$PATH
+echo PYTHON=$PYTHON
+
+# Define programs
+SETUP=/setup-$ARCH
+if [ $PYTHON = "python3" ]; then
+	PIP=pip3
+	EASYINSTALL=easy_install-3.6
+else
+	PIP=pip
+	EASYINSTALL=easy_install-2.7
+fi
+
+# Install prereqs
+echo "==== update gcc"
+$SETUP -q -P gcc-core,gcc-g++
+echo "==== update python"
+$SETUP -q -P $PYTHON,$PYTHON-numpy,$PYTHON-devel,$PYTHON,$PYTHON-setuptools,$PYTHON-nose
+echo "==== get modules"
+$EASYINSTALL pip
+$EASYINSTALL mock
+#$PIP install mock
+
+# Check versions
+echo "==== Check versions"
+"$ANT_HOME"/bin/ant -version
+$PYTHON --version
+
+echo "==== Check modules"
+$PYTHON -c 'import pip; print(sorted(["%s==%s" % (i.key, i.version) for i in pip.get_installed_distributions()]))'
+
+# Get the arch size
+echo "==== Check arch"
+$PYTHON -c "import struct; print(struct.calcsize('P') * 8)"
+
+# Build the test harness
+echo "==== Build test"
+"$ANT_HOME"/bin/ant -f test/build.xml
+
+# Install the package
+echo "==== Build module"
+$PYTHON setup.py install
+

--- a/appveyor/runTestsuite.ps1
+++ b/appveyor/runTestsuite.ps1
@@ -1,45 +1,9 @@
-function xslt_transform($xml, $xsl, $output)
-{
-	trap [Exception]
-	{
-	    Write-Host $_.Exception
-	}
-	
-	$xslt = New-Object System.Xml.Xsl.XslCompiledTransform
-	$xslt.Load($xsl)
-	$xslt.Transform($xml, $output)
+cd $env:APPVEYOR_BUILD_FOLDER
+nosetests test/jpypetest --all-modules --with-xunit
+$success = $?
+Write-Host "result code of nosetests:" $success
+
+# return exit code of testsuite
+if ( -not $success) {
+   throw "testsuite not successful"
 }
-
-function upload($file) {
-    trap [Exception]
-    {
-        Write-Host $_.Exception
-    }
-
-    $wc = New-Object 'System.Net.WebClient'
-    $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", $file)
-}
-
-function run {
-    cd $env:APPVEYOR_BUILD_FOLDER
-    $stylesheet =  "test/transform_xunit_to_appveyor.xsl"
-    $input = "nosetests.xml"
-    $output = "test/transformed.xml"
-    
-    nosetests test/jpypetest --all-modules --with-xunit
-    $success = $?
-    Write-Host "result code of nosetests:" $success
-
-    xslt_transform $input $stylesheet $output
-
-    upload $output
-    Push-AppveyorArtifact $input
-    Push-AppveyorArtifact $output
-    
-    # return exit code of testsuite
-    if ( -not $success) {
-        throw "testsuite not successful"
-    }
-}
-
-run

--- a/appveyor/runTestsuite.sh
+++ b/appveyor/runTestsuite.sh
@@ -1,0 +1,16 @@
+export PATH="/bin:/usr/bin:$PATH"
+cd $APPVEYOR_BUILD_FOLDER
+
+if [ $PYTHON = "python3" ]; then
+	NOSETESTS="nosetests-3.6"
+else
+	NOSETESTS="nosetests-2.7"
+fi
+
+echo "==== Run test.jpypetest"
+$NOSETESTS -v --with-xunit --all-modules -s test.jpypetest
+
+status=$?
+echo "result code of nosetests:" $status 
+
+exit $status

--- a/appveyor/upload.ps1
+++ b/appveyor/upload.ps1
@@ -1,0 +1,36 @@
+function xslt_transform($xml, $xsl, $output)
+{
+	trap [Exception]
+	{
+	    Write-Host $_.Exception
+	}
+	
+	$xslt = New-Object System.Xml.Xsl.XslCompiledTransform
+	$xslt.Load($xsl)
+	$xslt.Transform($xml, $output)
+}
+
+function upload($file) {
+    trap [Exception]
+    {
+        Write-Host $_.Exception
+    }
+
+    $wc = New-Object 'System.Net.WebClient'
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", $file)
+}
+
+function run {
+    cd $env:APPVEYOR_BUILD_FOLDER
+    $stylesheet =  "test/transform_xunit_to_appveyor.xsl"
+    $input = "nosetests.xml"
+    $output = "test/transformed.xml"
+    
+    xslt_transform $input $stylesheet $output
+
+    upload $output
+    Push-AppveyorArtifact $input
+    Push-AppveyorArtifact $output
+}
+
+run

--- a/jpype/__init__.py
+++ b/jpype/__init__.py
@@ -22,6 +22,7 @@ from ._jproxy import *
 from ._jexception import *
 from ._core import *
 from ._gui import *
+from ._classpath import *
 
 from . import JClassUtil
 

--- a/jpype/_classpath.py
+++ b/jpype/_classpath.py
@@ -1,0 +1,86 @@
+import os as _os
+import sys as _sys
+import glob as _glob
+
+__all__=['addClassPath', 'getClassPath']
+
+_CLASSPATHS=set()
+_SEP = _os.path.pathsep
+if _sys.platform=='cygwin':
+    _SEP=';'
+
+def _init():
+    global _CLASSPATHS
+    global _SEP
+    classpath=_os.environ.get("CLASSPATH")
+    if classpath:
+        _CLASSPATHS|=set(classpath.split(_SEP))
+
+_init()
+
+# Cygwin needs to convert to windows paths
+if _sys.platform=='cygwin':
+    _root=None
+    def _get_root():
+        global _root
+        if _root!=None:
+            return _root
+        import subprocess
+        proc = subprocess.Popen("cygpath -wa /", shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT, close_fds=True)
+        _root=proc.stdout.read().strip().decode('utf-8')
+        return _root
+
+    def _splitpath(path):
+        parts=[]
+        (path, tail)=_os.path.split( path)
+        while path and tail:
+             parts.insert(0,tail)
+             (path,tail)=_os.path.split(path)
+        return parts
+
+    def _posix2win(directory):
+        root=_get_root()
+        directory=_os.path.abspath(directory)
+        paths=_splitpath(directory)
+        if paths[0]=="cygdrive":
+            paths.pop(0)
+            drive=paths.pop(0)
+            paths.insert(0, "%s:"%drive)
+            return '\\'.join(paths)
+        paths.insert(0,root)
+        return '\\'.join(paths)
+    # needed for testing
+    __all__.append("_posix2win")
+
+def addClassPath(path1):
+    """ Add a path to the java class path"""
+    global _CLASSPATHS
+    path1=_os.path.abspath(path1)
+    if _sys.platform=='cygwin':
+        path1=_posix2win(path1)
+    _CLASSPATHS.add(str(path1))
+
+def getClassPath():
+    """ Get the full java class path.
+
+    Includes user added paths and the environment CLASSPATH.
+    """
+    global _CLASSPATHS
+    global _SEP
+    out=[]
+    for path in _CLASSPATHS:
+        if path=='':
+            continue
+        if path.endswith('*'):
+            paths=_glob.glob(path+".jar")
+            if len(path)==0:
+                continue 
+            out.extend(paths)
+        else:
+            out.append(path)
+    return _SEP.join(out)
+
+
+#print(getClassPath())

--- a/jpype/_jvmfinder.py
+++ b/jpype/_jvmfinder.py
@@ -16,6 +16,7 @@
 #*****************************************************************************
 
 import os
+import sys
 
 # ------------------------------------------------------------------------------
 
@@ -55,6 +56,7 @@ class JVMFinder(object):
         found_jamvm = False
         non_supported_jvm = ('cacao', 'jamvm')
         found_non_supported_jvm = False
+
         # Look for the file
         for root, _, names in os.walk(java_home):
             if self._libfile in names:
@@ -149,6 +151,10 @@ class JVMFinder(object):
         if java_home and os.path.exists(java_home):
             # Get the real installation path
             java_home = os.path.realpath(java_home)
+
+            # Cygwin has a bug in realpath
+            if not os.path.exists(java_home):
+                java_home = os.getenv("JAVA_HOME")
 
             # Look for the library file
             return self.find_libjvm(java_home)

--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -252,7 +252,7 @@ class _JImportLoader:
     def create_module(self, spec):
         global _initialized
         if not _initialized:
-            raise RuntimeError("Attempt to create modules without jvm")
+            raise ImportError("Attempt to create java modules without jvm")
 
         # Handle creating the java name based on the path
         parts = spec.name.split('.')

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -46,7 +46,16 @@
 #endif
 
 #ifdef WIN32
-	#ifdef __GNUC__
+	#if defined(__CYGWIN__)
+		// jni_md.h does not work for cygwin.  Use this instead.
+		#define _JAVASOFT_JNI_MD_H_
+		#define JNIEXPORT __declspec(dllexport)
+		#define JNIIMPORT __declspec(dllimport)
+		#define JNICALL __stdcall
+		typedef int jint;
+		typedef long long jlong;
+		typedef signed char jbyte;
+	#elif defined(__GNUC__)
 		// JNICALL causes problem for function prototypes .. since I am not defining any JNI methods there is no need for it
 		#undef JNICALL
 		#define JNICALL

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,14 @@ else:
 if sys.platform == 'win32':
     platform_specific['libraries'] = ['Advapi32']
     platform_specific['define_macros'] = [('WIN32', 1)]
+    platform_specific['extra_compile_args'] = ['/Zi', '/EHsc']
+    platform_specific['extra_link_args'] = ['/DEBUG']
+    jni_md_platform = 'win32'
+ 
+elif sys.platform == 'cygwin' :
+    platform_specific['libraries'] = ['Advapi32']
+    platform_specific['define_macros'] = [('WIN32', 1)]
+    platform_specific['extra_link_args'] = ['-g3']
     jni_md_platform = 'win32'
 
 elif sys.platform == 'darwin':
@@ -87,6 +95,7 @@ elif sys.platform.startswith('freebsd'):
     jni_md_platform = 'freebsd'
 
 else:
+    jni_md_platform = None
     warnings.warn("Your platform is not being handled explicitly."
                   " It may work or not!", UserWarning)
 

--- a/test/bulletproof.py
+++ b/test/bulletproof.py
@@ -48,7 +48,6 @@ class TestJpypeModule(unittest.TestCase):
             expect=c[1]
             if expect==None:
                 method(*args)
-                #print("PASS: %s => None "%n)
             else:
                 self.assertRaises(expect, method, *args)
 

--- a/test/java_dom.py
+++ b/test/java_dom.py
@@ -52,6 +52,6 @@ for i in range(count) :
     output(el)
 
 t2 = time.time()
-print count, "iterations in", t2-t, "seconds"
+print( count, "iterations in", t2-t, "seconds")
 
 shutdownJVM()

--- a/test/jpypetest/__init__.py
+++ b/test/jpypetest/__init__.py
@@ -1,5 +1,5 @@
 #*****************************************************************************
-#   Copyright 2004-2008 Steve Menard
+#   Copyright 2017 Karl Einar Nelson
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -14,3 +14,42 @@
 #   limitations under the License.
 #
 #*****************************************************************************
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+from inspect import isclass
+
+def importAll():
+    # Import in local scope to keep namespace clean
+    import os as _os
+
+    # Search through all modules in the toplevel directory
+    for _file in _os.listdir(_os.path.dirname(__file__)):
+
+        # Find all modules in the directory
+        if _file.startswith('__') or _file[-3:] != '.py':
+            continue
+
+        # import module
+        _name = _file[:-3]
+        exec("from . import %s"% _name)
+        _module=globals()[_name]
+        for n,cls in _module.__dict__.items():
+            try:
+                if not issubclass(cls, unittest.TestCase):
+                    continue
+                globals()[n]=cls
+            except TypeError as ex:
+                pass
+
+importAll()
+
+# Use ant to build the test harness before running the tests
+#   ant -f test/build.xml
+#
+# To run all tests bench call at the the top level directory
+#   nosetests -v test.jpypetest 
+#
+# Individual tests can be called by their module name, such as
+#   nosetests -v test.jpypetest.array

--- a/test/jpypetest/common.py
+++ b/test/jpypetest/common.py
@@ -30,11 +30,12 @@ class JPypeTestCase(unittest.TestCase) :
     def setUp(self):
         if not jpype.isJVMStarted():
             root = path.dirname(path.abspath(path.dirname(__file__)))
+            jpype.addClassPath(path.join(root, 'classes'))
             jvm_path = jpype.getDefaultJVMPath()
             logger = logging.getLogger(__name__)
             logger.info("Running testsuite using JVM %s" % jvm_path)
             classpath_arg = "-Djava.class.path=%s"
-            classpath_arg %= path.join(root, 'classes')
+            classpath_arg %= jpype.getClassPath()
             jpype.startJVM(jvm_path, "-ea",
                            # "-Xcheck:jni",
                            "-Xmx256M", "-Xms16M", classpath_arg)
@@ -44,3 +45,4 @@ class JPypeTestCase(unittest.TestCase) :
 
     def tearDown(self):
         pass
+

--- a/test/jpypetest/serial.py
+++ b/test/jpypetest/serial.py
@@ -16,6 +16,7 @@
 #*****************************************************************************
 from jpype import JException, java, JavaException, JProxy, JClass
 import os
+import sys
 import tempfile
 import traceback
 from . import common
@@ -31,7 +32,11 @@ class SerializationTestCase(common.JPypeTestCase):
 
     def testSerialize(self):
         o = JClass("jpype.serial.SerializationTest")()
-        fos = java.io.FileOutputStream(self.tempname)
+        tmp = self.tempname
+        if sys.platform=='cygwin':
+            from jpype import _posix2win
+            tmp = _posix2win(tmp)
+        fos = java.io.FileOutputStream(tmp)
         oos = java.io.ObjectOutputStream(fos)
         oos.writeObject(o)
         oos.flush()

--- a/test/test_awt.py
+++ b/test/test_awt.py
@@ -2,13 +2,13 @@ from jpype import *
 import time
 
 def run():
-    print 'Thread started'
+    print('Thread started')
     try:
-        print repr(java.awt.Frame)
+        print(repr(java.awt.Frame))
         javax.swing.JFrame("Test Frame").setVisible(True)
         shutdownGuiEnvironment()
-    except JException, ex :
-        print ex
+    except JException as ex :
+        print(ex)
 
 
 startJVM(getDefaultJVMPath())


### PR DESCRIPTION
Okay yet another try at getting the cygwin + appveyor patch together.

This patch
* Adds cygwin
* Adds cygwin to the appveyor
* Changes the ant pattern for use by appveyor
* Updates the test pattern for nosetests because cygwin nose required a different pattern (may deprecate testsuite.py as now "nosetests test.jpypetest" does same function.
* Adds classpath for support of cygwin and pulling CLASSPATH env into the jvm
* Cleans up some stray tests for py3.  (Mostly accidental stuff as I was trying to get nosetests working)

This pull is independent of all other pull requests.  (other redundant pulls are now closed)