### PR TITLE
Exception during multithreaded execution of proxies

### DIFF
--- a/native/common/jp_typemanager.cpp
+++ b/native/common/jp_typemanager.cpp
@@ -84,12 +84,12 @@ JPClass* findClass(const JPTypeName& name)
 	cleaner.addLocal(cls);
 
 	JPClass* res = new JPClass(name, cls);
-	
+	// Finish loading it
+	res->postLoad();
 	// Register it here before we do anything else
 	javaClassMap[name.getSimpleName()] = res;
-	
-	// Finish loading it
-	res->postLoad();		
+
+
 
 	return res;
 	TRACE_OUT;

--- a/native/common/jp_typemanager.cpp
+++ b/native/common/jp_typemanager.cpp
@@ -12,8 +12,8 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
-*****************************************************************************/   
+
+*****************************************************************************/
 #include <jpype.h>
 
 namespace {
@@ -66,12 +66,12 @@ JPClass* findClass(const JPTypeName& name)
 {
 	// Fist check in the map ...
 	JavaClassMap::iterator cur = javaClassMap.find(name.getSimpleName());
-	
+
 	if (cur != javaClassMap.end())
 	{
 		return cur->second;
 	}
-	
+
 	TRACE_IN("JPTypeManager::findClass");
 	TRACE1(name.getSimpleName());
 
@@ -89,8 +89,6 @@ JPClass* findClass(const JPTypeName& name)
 	// Register it here before we do anything else
 	javaClassMap[name.getSimpleName()] = res;
 
-
-
 	return res;
 	TRACE_OUT;
 }
@@ -99,12 +97,12 @@ JPArrayClass* findArrayClass(const JPTypeName& name)
 {
 	// Fist check in the map ...
 	JavaArrayClassMap::iterator cur = javaArrayClassMap.find(name.getSimpleName());
-	
+
 	if (cur != javaArrayClassMap.end())
 	{
 		return cur->second;
 	}
-	
+
 	// No we havent got it .. lets load it!!!
 	JPCleaner cleaner;
 	jclass cls = JPEnv::getJava()->FindClass(name.getNativeName().c_str());
@@ -112,10 +110,10 @@ JPArrayClass* findArrayClass(const JPTypeName& name)
 	cleaner.addLocal(cls);
 
 	JPArrayClass* res = new JPArrayClass(name, cls);
-	
+
 	// Register it here before we do anything else
 	javaArrayClassMap[name.getSimpleName()] = res;
-	
+
 	return res;
 }
 
@@ -123,12 +121,12 @@ JPType* getType(const JPTypeName& t)
 {
 	TRACE_IN("JPTypeManager::getType");
 	map<JPTypeName::ETypes, JPType*>::iterator it = typeMap.find(t.getType());
-	
+
 	if (it != typeMap.end())
 	{
 		return it->second;
 	}
-	
+
 	if (t.getType() == JPTypeName::_array)
 	{
 		JPArrayClass* c = findArrayClass(t);

--- a/test/harness/jpype/proxy/ProxyExecutor.java
+++ b/test/harness/jpype/proxy/ProxyExecutor.java
@@ -1,0 +1,120 @@
+//*****************************************************************************
+//Copyright 2004-2008 Steve Menard
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+//
+//*****************************************************************************
+package jpype.proxy;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class ProxyExecutor {
+    private ExecutorService executor;
+
+    private List<Future<Integer>> executedTasks = new ArrayList<Future<Integer>>();
+    private List<ProxyCaller> proxies = new ArrayList<ProxyCaller>();
+
+    public ProxyExecutor(int noOfThreads) {
+        executor = Executors.newFixedThreadPool(noOfThreads);
+    }
+
+    public void shutdown() {
+        executor.shutdown(); // Disable new tasks from being submitted
+        try {
+            // Wait a while for existing tasks to terminate
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow(); // Cancel currently executing tasks
+                // Wait a while for tasks to respond to being cancelled
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS))
+                    System.err.println("Pool did not terminate");
+            }
+        } catch (InterruptedException ie) {
+            // (Re-)Cancel if current thread also interrupted
+            executor.shutdownNow();
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void registerProxy(TestInterface4 proxy, int noOfExecutions) {
+
+        for (int i = 0; i < noOfExecutions; i++) {
+            proxies.add(new ProxyCaller(proxy));
+        }
+    }
+
+    public int getExpectedTasks() {
+        return proxies.size();
+    }
+
+    public void runExecutor() {
+
+        // Collections.shuffle(proxies);
+
+        for (ProxyCaller proxy : proxies) {
+            Future<Integer> future = executor.submit(proxy);
+            executedTasks.add(future);
+        }
+
+    }
+
+    public int waitForExecutedTasks() {
+        int returns = 0;
+
+        for (Future<Integer> task : executedTasks) {
+            try {
+                returns += task.get();
+            } catch (Exception ex) {
+                System.out.println("An exception has thrown during execution");
+                ex.printStackTrace();
+            }
+        }
+        return returns;
+    }
+
+    public class ProxyCaller implements Callable<Integer> {
+
+        private TestInterface4 proxy;
+
+        public ProxyCaller(TestInterface4 proxy) {
+            this.proxy = proxy;
+        }
+
+        @Override
+        public Integer call() throws Exception {
+
+            int result = 0;
+
+            try {
+                int intValue = proxy.testMethodInt();
+                ReturnObject objectValue = proxy.testMethodObject();
+                String stringValue = proxy.testMethodString();
+                List<ReturnObject> listValue = proxy.testMethodList(5);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+
+            return 1; //result;
+        }
+
+    }
+}

--- a/test/harness/jpype/proxy/ReturnObject.java
+++ b/test/harness/jpype/proxy/ReturnObject.java
@@ -1,0 +1,31 @@
+//*****************************************************************************
+//Copyright 2004-2008 Steve Menard
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+//
+//*****************************************************************************
+package jpype.proxy;
+
+
+public class ReturnObject {
+    private int number;
+
+    public ReturnObject(int number){
+        this.number = number;
+    }
+
+    public int getNumber(){
+        return number;
+    }
+
+}

--- a/test/harness/jpype/proxy/TestInterface4.java
+++ b/test/harness/jpype/proxy/TestInterface4.java
@@ -1,0 +1,14 @@
+package jpype.proxy;
+
+import java.util.List;
+
+public interface TestInterface4 {
+
+    ReturnObject testMethodObject();
+
+    int testMethodInt();
+
+    String testMethodString();
+
+    List<ReturnObject> testMethodList(int noOfValues);
+}

--- a/test/jpypetest/proxy_multithreaded.py
+++ b/test/jpypetest/proxy_multithreaded.py
@@ -1,0 +1,145 @@
+#*****************************************************************************
+#   Copyright 2004-2008 Steve Menard
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#*****************************************************************************
+from jpype import *
+from . import common
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import time
+
+
+class C:
+    def testMethodInt(self):
+        return 5
+
+    def testMethodObject(self):
+        return JPackage("jpype.proxy").ReturnObject(3)
+
+    def testMethodString(self):
+        return "Hallo"
+
+    def testMethodList(self, noOfValues):
+        responses = list()
+        for i in range(0, noOfValues):
+            responses.append(JPackage("jpype.proxy").ReturnObject(i))
+        return java.util.Arrays.asList(responses)
+
+
+class ThreadCallbackImpl:
+    def __init__(self):
+        self.values = []
+
+    def notifyValue(self, val):
+        self.values.append(val)
+
+class ProxyMultiThreadedTestCase(common.JPypeTestCase):
+
+    def setUp(self):
+        super(ProxyMultiThreadedTestCase, self).setUp()
+        self.package = JPackage("jpype.proxy")
+        self.executor = None
+
+
+    def tearDown(self):
+
+        if self.executor is not None:
+            self.executor.shutdown()
+
+
+    def testProxyWithSingleThreadExecution(self):
+        """Test multiple proxy calls with a single threaded executor.
+
+        The Java part will only call one proxy method (longer running methods)
+        at a time.
+
+        The methods should run correctly.
+        """
+
+        proxy = JProxy(self.package.TestInterface4, inst=C())
+
+        self.executor = self.package.ProxyExecutor(1)
+        self.executor.registerProxy(proxy,10)
+
+        # register proxy executions
+        # threads
+
+        self.executor.runExecutor()
+        result = self.executor.waitForExecutedTasks()
+        expected = self.executor.getExpectedTasks()
+        self.assertEqual(result, expected, "Executed Tasks should be the same.")
+
+
+    def testProxyWithMultipleThreadExecutionSingleCallbackInstance(self):
+        """Test multiple proxy calls with different threads at the same time.
+
+        The Java part will call the same callback instance from different
+        threads at a time.
+
+        Jpype library will throw an exception and the proxy method won't be
+        called:
+            java.lang.RuntimeException: Python exception thrown:
+                AttributeError: 'NoneType' object has no attribute 'getName'
+	        at jpype.JPypeInvocationHandler.hostInvoke(Native Method)
+            at jpype.JPypeInvocationHandler.invoke(
+                JPypeInvocationHandler.java:10)
+            ...
+        """
+        proxy = JProxy(self.package.TestInterface4, inst=C())
+
+        self.executor = self.package.ProxyExecutor(10)
+        self.executor.registerProxy(proxy,100)
+
+        # register proxy executions
+        # threads
+        self.executor.runExecutor()
+        result = self.executor.waitForExecutedTasks()
+
+        expected = self.executor.getExpectedTasks()
+        self.assertEqual(result, expected, "Executed Tasks should be the same.")
+
+    def testProxyWithMultipleThreadExecutionMultiCallbackInstances(self):
+        """Test multiple proxy calls with different threads at the same time.
+
+        The Java part will call the proxy method from different callback
+        instances and from different threads at a time.
+
+        Jpype library will throw an exception and the proxy method won't be
+        called:
+            java.lang.RuntimeException: Python exception thrown:
+                AttributeError: 'NoneType' object has no attribute 'getName'
+	        at jpype.JPypeInvocationHandler.hostInvoke(Native Method)
+            at jpype.JPypeInvocationHandler.invoke(
+                JPypeInvocationHandler.java:10)
+            ...
+        """
+
+        self.executor = self.package.ProxyExecutor(10)
+
+        for i in range(0,5):
+            proxy = JProxy(self.package.TestInterface4, inst=C())
+            self.executor.registerProxy(proxy,15)
+
+        # register proxy executions
+        # threads
+
+        self.executor.runExecutor()
+        result = self.executor.waitForExecutedTasks()
+        expected = self.executor.getExpectedTasks()
+        self.assertEqual(result, expected, "Executed Tasks should be the same.")


### PR DESCRIPTION
During the execution of a registered proxy in a multithreaded application I get the following exception.

```
java.lang.RuntimeException: Python exception thrown: AttributeError: 'NoneType' object has no attribute 'getName'
 	at jpype.JPypeInvocationHandler.hostInvoke(Native Method)
 	at jpype.JPypeInvocationHandler.invoke(JPypeInvocationHandler.java:10)
	at com.sun.proxy.$Proxy18.handleMessage(Unknown Source)
```

The proxy is called from multiple threads using Java's ExecutorService with a fixed pool size. If I only run a single thread at once Jpype works perfectly but if I change to more than one thread execution at a time Jpype crashes.

During the execution of some specific test cases the exception turns into an access violation.
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x000007fef86a23c5, pid=7180, tid=1056
#
# JRE version: Java(TM) SE Runtime Environment (8.0_91-b15) (build 1.8.0_91-b15)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.91-b15 mixed mode windows-amd64 compressed oops)
# Problematic frame:
# C  [_jpype.cp35-win_amd64.pyd+0x23c5]
#
# Failed to write core dump. Minidumps are not enabled by default on client versions of Windows
#
# An error report file with more information is saved as:
# C:\DATA\Software\jpype\hs_err_pid7180.log
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
```

## Solution

The return value of the called proxy method can't be converted back to a Java object.
The constructors of the corresponding Java class were null.

**Call Stack**
- jpproxy.cpp (95): canConvertToJava
- jp_primitivetypes.cpp (19): newInstance
- jp_class.cpp (469): invoke_constructors
**Error:** m_constructors in JPCLass was null

The problem can be simply solved by completely loading the Java class before it is registered to Jpype. (swapping `postLoad()` and register)

```java
JPClass* res = new JPClass(name, cls);
// Finish loading it
res->postLoad();
//Register it here before we do anything else
javaClassMap[name.getSimpleName()] = res;
```


**System settings:**
Python 3.5
OS: Windows 7 , 64 bit
vm_info: Java HotSpot(TM) 64-Bit Server VM (25.91-b15) for windows-amd64 JRE (1.8.0_91-b15)