### PR TITLE
Support for java.lang.Class<>

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,17 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 - **Next version - unreleased**
 
+  - Support of java.lang.Class<> 
+    - java.lang.Object().getClass() on Java objects returns a java.lang.Class 
+      rather than the Python class
+    - java.lang.Object().__class__ on Java objects returns the python class 
+      as do all python objects
+    - java.lang.Object.class_ maps to the java statement 'java.lang.Object.class' and
+      returns the java.lang.Class<java.lang.Object> 
+    - java.lang.Class supports reflection methods
+    - private fields and methods can be accessed via reflection
+    - annotations are avaiable via reflection
+
   - Java objects and arrays will not accept setattr unless the 
     attribute corresponds to a java method or field whith 
     the exception of private attributes that begin with 

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -43,6 +43,7 @@ def registerJVMInitializer(func):
     _initializers.append(func)
 
 def _initialize():
+    _properties._initialize()
     _jclass._initialize()
     _jarray._initialize()
     _jwrapper._initialize()
@@ -50,7 +51,6 @@ def _initialize():
     _jexception._initialize()
     _jcollection._initialize()
     _jobject._initialize()
-    _properties._initialize()
     nio._initialize()
     reflect._initialize()
     for func in _initializers:

--- a/jpype/_jarray.py
+++ b/jpype/_jarray.py
@@ -29,8 +29,8 @@ _CLASSES = {}
 _CUSTOMIZERS = []
 
 def _initialize():
-    _jpype.setJavaArrayClass(_JavaArrayClass)
-    _jpype.setGetJavaArrayClassMethod(_getClassFor)
+    _jpype.setResource('JavaArrayClass',_JavaArrayClass)
+    _jpype.setResource('GetJavaArrayClassMethod',_getClassFor)
 
     registerArrayCustomizer(CharArrayCustomizer())
     registerArrayCustomizer(ByteArrayCustomizer())

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -156,12 +156,12 @@ class _JavaObject(object):
 #       inherites from _JavaClass
 #     Foo.__javaclass__ - private jpype capsule holding C resources
 #     Foo.__class__ - python class type for class (will be Foo$$Static)
+#     Foo.class_ - java.lang.Class<Foo>
 #
 #     Foo() - instance of Foo which wraps a java object
 #       inherits from _JavaObject
 #     Foo().__class__ - ptthon class type for object (will be Foo)
-#     Foo().getClass() - Should be java.lang.Class<Foo> but is currently
-#       a reference to Python class Foo
+#     Foo().getClass() - java.lang.Class<Foo> 
 #
 
 

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -22,6 +22,7 @@ _CLASSES = {}
 
 _SPECIAL_CONSTRUCTOR_KEY = "This is the special constructor key"
 
+_JAVACLASS = None
 _JAVAOBJECT = None
 _JAVATHROWABLE = None
 _COMPARABLE = None
@@ -34,15 +35,16 @@ _COMPARABLE_METHODS = {
         }
 
 def _initialize():
-    global _COMPARABLE, _JAVAOBJECT, _JAVATHROWABLE, _RUNTIMEEXCEPTION
+    global _COMPARABLE, _JAVACLASS, _JAVAOBJECT, _JAVATHROWABLE, _RUNTIMEEXCEPTION
 
     _JAVAOBJECT = JClass("java.lang.Object")
+    _JAVACLASS = JClass("java.lang.Class")
     _JAVATHROWABLE = JClass("java.lang.Throwable")
     _RUNTIMEEXCEPTION = JClass("java.lang.RuntimeException")
-#    _jpype.setJavaLangObjectClass(_JAVAOBJECT)
-    _jpype.setJavaLangObjectClass(_JavaObject)
-    _jpype.setGetClassMethod(_getClassFor)
-    _jpype.setSpecialConstructorKey(_SPECIAL_CONSTRUCTOR_KEY)
+    _jpype.setResource('JavaClass', _JavaClass)
+    _jpype.setResource('JavaObject', _JavaObject)
+    _jpype.setResource('GetClassMethod',_getClassFor)
+    _jpype.setResource('SpecialConstructorKey',_SPECIAL_CONSTRUCTOR_KEY)
 
 
 def registerClassCustomizer(c):
@@ -144,6 +146,24 @@ class _JavaObject(object):
     """
     pass
 
+#  JPype has several class types (assuming Foo is a java class)
+#     Foo$$Static - python meta class for Foo holding
+#       properties for static fields and static methods
+#
+#     Foo - Python class which produces a Foo object() 
+#       and access to static fields and stataic methods
+#       in addition as a class type it holds all the fields and methods 
+#       inherites from _JavaClass
+#     Foo.__javaclass__ - private jpype capsule holding C resources
+#     Foo.__class__ - python class type for class (will be Foo$$Static)
+#
+#     Foo() - instance of Foo which wraps a java object
+#       inherits from _JavaObject
+#     Foo().__class__ - ptthon class type for object (will be Foo)
+#     Foo().getClass() - Should be java.lang.Class<Foo> but is currently
+#       a reference to Python class Foo
+#
+
 
 class _JavaClass(type):
     """ Base class for all Java Class types. 
@@ -151,6 +171,7 @@ class _JavaClass(type):
         Use isinstance(obj, jpype.JavaClass) to test for a class.
     """
     def __new__(cls, jc):
+        global _JAVACLASS
         bases = []
         name = jc.getName()
 
@@ -229,6 +250,7 @@ class _JavaClass(type):
                 meta_bases.append(i.__metaclass__)
 
         static_fields['mro'] = _mro_override_topsort
+        static_fields['class_']= property(lambda self: _JAVACLASS.forName(name,True, JClass('java.lang.ClassLoader').getSystemClassLoader()), None)
 
         metaclass = type.__new__(_MetaClassForMroOverride, name + "$$Static", tuple(meta_bases),
                                  static_fields)

--- a/jpype/_jexception.py
+++ b/jpype/_jexception.py
@@ -57,7 +57,7 @@ class JavaException(Exception):
         return self.__javaobject__.toString()
 
 def _initialize():
-    _jpype.setJavaExceptionClass(JavaException)
+    _jpype.setResource('JavaExceptionClass', JavaException)
 
 def _makePythonException(name, bc):
     if name in _CLASSES:

--- a/jpype/_jproxy.py
+++ b/jpype/_jproxy.py
@@ -26,7 +26,7 @@ if sys.version > '3':
     unicode = str
 
 def _initialize():
-    _jpype.setProxyClass(JProxy)
+    _jpype.setResource('ProxyClass',JProxy)
 
 class JProxy(object):
     def __init__(self, intf, dict=None, inst=None):

--- a/jpype/_jwrapper.py
+++ b/jpype/_jwrapper.py
@@ -26,8 +26,8 @@ if sys.version > '3':
     long = int
 
 def _initialize():
-    _jpype.setWrapperClass(_JWrapper)
-    _jpype.setStringWrapperClass(JString)
+    _jpype.setResource('WrapperClass', _JWrapper)
+    _jpype.setResource('StringWrapperClass', JString)
 
 class _JWrapper(object):
     def __init__(self, v):

--- a/jpype/_properties.py
+++ b/jpype/_properties.py
@@ -16,6 +16,7 @@
 #*****************************************************************************
 import _jpype
 from . import _jclass
+from ._pykeywords import KEYWORDS
 
 _PROPERTY_ACCESSOR_PREFIX_LEN = 3
 
@@ -70,6 +71,12 @@ class PropertiesCustomizer(object) :
     def customize(self, class_name, jc, bases, members) :
         accessor_pairs = _extract_accessor_pairs(members)
         for attr_name, (getter, setter) in accessor_pairs.items():
+            # class is will be static to match Type.class in Java
+            if attr_name=='class':
+                continue
+            # Handle keyword conflicts
+            if attr_name in KEYWORDS:
+                attr_name += "_"
             if attr_name in members:
                 if not getter:
                     # add default getter if we

--- a/native/common/include/jp_objecttypes.h
+++ b/native/common/include/jp_objecttypes.h
@@ -102,24 +102,4 @@ public : // JPType implementation
 	virtual jvalue     convertToJava(HostRef* obj);
 };
 
-class JPClassType : public JPObjectType
-{
-public :
-	JPClassType() : JPObjectType(JPTypeName::_class, JPTypeName::fromSimple("java.lang.Class"))
-	{
-	}
-	
-	virtual ~JPClassType()
-	{
-	}
-
-protected :
-	virtual jclass    getClass() const;
-
-public : // JPType implementation
-	virtual HostRef*  asHostObject(jvalue val);
-	virtual EMatchType canConvertToJava(HostRef* obj);
-	virtual jvalue     convertToJava(HostRef* obj);
-};
-
 #endif // _JPPOBJECTTYPE_H_

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -182,7 +182,7 @@ jvalue JPArrayClass::convertToJavaVector(vector<HostRef*>& refs, size_t start, s
 	jvalue res;
 	res.l = array;
 		
-	for (int i = start; i < end ; i++)
+	for (size_t i = start; i < end ; i++)
 	{
 		m_ComponentType->setArrayItem(array, i-start, refs[i]);
 	}

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -285,6 +285,15 @@ EMatchType JPClass::canConvertToJava(HostRef* obj)
 				return _explicit;
 			}
 		}
+
+		// Handle a Python class which wraps java class 
+		if (simpleName == "java.lang.Class")
+		{
+			if (JPEnv::getHost()->isClass(obj))
+			{
+				return _exact;
+			}
+		}
 	
 		if (simpleName == "java.lang.Object")
 		{
@@ -430,6 +439,13 @@ jvalue JPClass::convertToJava(HostRef* obj)
 			JPTypeName name = JPTypeName::fromSimple("java.lang.String");
 			JPType* type = JPTypeManager::getType(name);
 			return type->convertToJava(obj);
+		}
+
+		if (simpleName == "java.lang.Class")
+		{
+			JPClass* w = JPEnv::getHost()->asClass(obj);
+		  jclass lr = w->getClass();
+		  res.l = lr;
 		}
 
 		if (simpleName == "java.lang.Object")

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -211,7 +211,7 @@ HostRef* JPClass::getStaticAttribute(const string& name)
 
 HostRef* JPClass::asHostObject(jvalue obj)
 {
-	TRACE_IN("JPClass::asPyObject");
+	TRACE_IN("JPClass::asHostObject");
 	if (obj.l == NULL)
 	{
 		return JPEnv::getHost()->getNone();

--- a/native/common/jp_methodoverload.cpp
+++ b/native/common/jp_methodoverload.cpp
@@ -161,11 +161,6 @@ EMatchType matchVars(vector<HostRef*>& arg, size_t start, JPType* vartype)
 	{
 		HostRef* obj = arg[i];
 		EMatchType match = type->canConvertToJava(obj);
-//		if (JPEnv::getHost()->isObject(obj))
-//		{
-//			JPObject* o = JPEnv::getHost()->asObject(obj);
-//			JPClass* oc = o->getClass();
-//		}
 
 		if (match < _implicit)
 		{

--- a/native/common/jp_methodoverload.cpp
+++ b/native/common/jp_methodoverload.cpp
@@ -161,11 +161,11 @@ EMatchType matchVars(vector<HostRef*>& arg, size_t start, JPType* vartype)
 	{
 		HostRef* obj = arg[i];
 		EMatchType match = type->canConvertToJava(obj);
-		if (JPEnv::getHost()->isObject(obj))
-		{
-			JPObject* o = JPEnv::getHost()->asObject(obj);
-			JPClass* oc = o->getClass();
-		}
+//		if (JPEnv::getHost()->isObject(obj))
+//		{
+//			JPObject* o = JPEnv::getHost()->asObject(obj);
+//			JPClass* oc = o->getClass();
+//		}
 
 		if (match < _implicit)
 		{

--- a/native/common/jp_objecttypes.cpp
+++ b/native/common/jp_objecttypes.cpp
@@ -207,7 +207,9 @@ jobject JPObjectType::convertToJavaObject(HostRef* obj)
 
 HostRef* JPObjectType::asHostObjectFromObject(jvalue val)
 {
+	TRACE_IN("JPObjectType::asHostObjectFromObject");
 	return asHostObject(val);
+	TRACE_OUT;
 }
 
 HostRef* JPObjectType::convertToDirectBuffer(HostRef* src)
@@ -364,6 +366,7 @@ jclass JPStringType::getClass() const
 
 HostRef* JPClassType::asHostObject(jvalue val) 
 {
+	TRACE_IN("JPClassType::asHostObject");
 	jclass lclass = (jclass)val.l;
 	
 	JPTypeName name = JPJni::getName(lclass);
@@ -372,6 +375,7 @@ HostRef* JPClassType::asHostObject(jvalue val)
 
 	
 	return JPEnv::getHost()->newClass(res);
+	TRACE_OUT;
 }
 
 EMatchType JPClassType::canConvertToJava(HostRef* obj)

--- a/native/common/jp_objecttypes.cpp
+++ b/native/common/jp_objecttypes.cpp
@@ -207,9 +207,7 @@ jobject JPObjectType::convertToJavaObject(HostRef* obj)
 
 HostRef* JPObjectType::asHostObjectFromObject(jvalue val)
 {
-	TRACE_IN("JPObjectType::asHostObjectFromObject");
 	return asHostObject(val);
-	TRACE_OUT;
 }
 
 HostRef* JPObjectType::convertToDirectBuffer(HostRef* src)
@@ -360,80 +358,5 @@ jvalue JPStringType::convertToJava(HostRef* obj)
 jclass JPStringType::getClass() const
 {
 	return (jclass)JPEnv::getJava()->NewGlobalRef(JPJni::s_StringClass);
-}
-
-//-------------------------------------------------------------------------------
-
-HostRef* JPClassType::asHostObject(jvalue val) 
-{
-	TRACE_IN("JPClassType::asHostObject");
-	jclass lclass = (jclass)val.l;
-	
-	JPTypeName name = JPJni::getName(lclass);
-	
-	JPClass* res = JPTypeManager::findClass(name);
-
-	
-	return JPEnv::getHost()->newClass(res);
-	TRACE_OUT;
-}
-
-EMatchType JPClassType::canConvertToJava(HostRef* obj)
-{
-	JPCleaner cleaner;
-
-	if (JPEnv::getHost()->isNone(obj))
-	{
-		return _implicit;
-	}
-
-	if (JPEnv::getHost()->isClass(obj))
-	{
-		return _exact;
-	}
-
-	if (JPEnv::getHost()->isWrapper(obj))
-	{
-		JPTypeName name = JPEnv::getHost()->getWrapperTypeName(obj);
-
-		if (name.getType() == JPTypeName::_class)
-		{
-			return _exact;
-		}
-	}
-
-	return _none;
-}
-
-jvalue JPClassType::convertToJava(HostRef* obj)
-{
-	JPCleaner cleaner;
-
-	jvalue v;
-	if (JPEnv::getHost()->isNone(obj))
-	{
-		v.l = NULL;
-		return v;
-	}
-	
-	else if (JPEnv::getHost()->isWrapper(obj))
-	{
-		v = JPEnv::getHost()->getWrapperValue(obj);
-	}
-	else
-	{
-		JPClass* w = JPEnv::getHost()->asClass(obj);
-
-		jclass lr = w->getClass();
-
-		v.l = lr;
-	}
-
-	return v;		
-}
-
-jclass JPClassType::getClass() const
-{
-	return (jclass)JPEnv::getJava()->NewGlobalRef(JPJni::s_ClassClass);
 }
 

--- a/native/common/jp_typemanager.cpp
+++ b/native/common/jp_typemanager.cpp
@@ -48,7 +48,6 @@ void init()
 	typeMap[JPTypeName::_char] = new JPCharType();
 	typeMap[JPTypeName::_boolean] = new JPBooleanType();
 	typeMap[JPTypeName::_string] = new JPStringType();
-	//typeMap[JPTypeName::_class] = new JPClassType();
 
 	// Preload the "primitive" types
 	javaClassMap["byte"] = new JPClass(JPTypeName::fromSimple("byte"), JPJni::getByteClass());
@@ -122,7 +121,6 @@ JPArrayClass* findArrayClass(const JPTypeName& name)
 JPType* getType(const JPTypeName& t)
 {
 	TRACE_IN("JPTypeManager::getType");
-	TRACE2("class", t.getSimpleName());
 	map<JPTypeName::ETypes, JPType*>::iterator it = typeMap.find(t.getType());
 	
 	if (it != typeMap.end())

--- a/native/common/jp_typemanager.cpp
+++ b/native/common/jp_typemanager.cpp
@@ -48,7 +48,7 @@ void init()
 	typeMap[JPTypeName::_char] = new JPCharType();
 	typeMap[JPTypeName::_boolean] = new JPBooleanType();
 	typeMap[JPTypeName::_string] = new JPStringType();
-	typeMap[JPTypeName::_class] = new JPClassType();
+	//typeMap[JPTypeName::_class] = new JPClassType();
 
 	// Preload the "primitive" types
 	javaClassMap["byte"] = new JPClass(JPTypeName::fromSimple("byte"), JPJni::getByteClass());
@@ -122,6 +122,7 @@ JPArrayClass* findArrayClass(const JPTypeName& name)
 JPType* getType(const JPTypeName& t)
 {
 	TRACE_IN("JPTypeManager::getType");
+	TRACE2("class", t.getSimpleName());
 	map<JPTypeName::ETypes, JPType*>::iterator it = typeMap.find(t.getType());
 	
 	if (it != typeMap.end())

--- a/native/python/include/jpype_python.h
+++ b/native/python/include/jpype_python.h
@@ -52,19 +52,16 @@ namespace JPypeModule
 	PyObject* stopReferenceQueue(PyObject* obj);
 
 	PyObject* setConvertStringObjects(PyObject* obj, PyObject* args);
+	PyObject* setResource(PyObject* obj, PyObject* args);
 }
 
 namespace JPypeJavaClass
 {
 	PyObject* findClass(PyObject* obj, PyObject* args);
-	PyObject* setJavaLangObjectClass(PyObject* self, PyObject* arg);
-	PyObject* setGetClassMethod(PyObject* self, PyObject* arg);
-	PyObject* setSpecialConstructorKey(PyObject* self, PyObject* arg);
 };
 
 namespace JPypeJavaProxy
 {
-	PyObject* setProxyClass(PyObject* self, PyObject* arg);
 	PyObject* createProxy(PyObject*, PyObject* arg);
 };
 
@@ -77,20 +74,12 @@ namespace JPypeJavaArray
 	PyObject* setArraySlice(PyObject* self, PyObject* arg);
 	PyObject* newArray(PyObject* self, PyObject* arg);
 	PyObject* setArrayItem(PyObject* self, PyObject* arg);
-	PyObject* setGetJavaArrayClassMethod(PyObject* self, PyObject* arg);
-	PyObject* setJavaArrayClass(PyObject* self, PyObject* arg);
 	PyObject* setArrayValues(PyObject* self, PyObject* arg);
 };
 
 namespace JPypeJavaNio
 {
 	PyObject* convertToDirectBuffer(PyObject* self, PyObject* arg);
-};
-
-namespace JPypeJavaWrapper
-{
-	PyObject* setWrapperClass(PyObject* self, PyObject* arg);
-	PyObject* setStringWrapperClass(PyObject* self, PyObject* arg);
 };
 
 namespace JPypeJavaException

--- a/native/python/include/py_hostenv.h
+++ b/native/python/include/py_hostenv.h
@@ -30,15 +30,21 @@ public :
 	}
 	
 public :
-	void setJavaLangObjectClass(PyObject* obj)
+	void setPythonJavaObject(PyObject* obj)
 	{
-		m_JavaLangObject = obj;
+		m_PythonJavaObject = obj;
 	}
 
-	PyObject* getJavaLangObjectClass()
+	void setPythonJavaClass(PyObject* obj)
 	{
-		return m_JavaLangObject;
+		m_PythonJavaClass = obj;
 	}
+
+	PyObject* getPythoneJavaClass()
+	{
+		return m_PythonJavaClass;
+	}
+
 
 	void setJavaArrayClass(PyObject* obj)
 	{
@@ -123,7 +129,8 @@ public :
 	PyObject* getJavaShadowClass(JPClass* jc);
 
 private :
-	PyObject* m_JavaLangObject;
+	PyObject* m_PythonJavaObject;
+	PyObject* m_PythonJavaClass;
 	PyObject* m_JavaArrayClass;
 	PyObject* m_WrapperClass;
 	PyObject* m_StringWrapperClass;

--- a/native/python/include/py_hostenv.h
+++ b/native/python/include/py_hostenv.h
@@ -40,12 +40,6 @@ public :
 		m_PythonJavaClass = obj;
 	}
 
-	PyObject* getPythoneJavaClass()
-	{
-		return m_PythonJavaClass;
-	}
-
-
 	void setJavaArrayClass(PyObject* obj)
 	{
 		m_JavaArrayClass = obj;

--- a/native/python/jpype_javaarray.cpp
+++ b/native/python/jpype_javaarray.cpp
@@ -58,37 +58,6 @@ PyObject* JPypeJavaArray::findArrayClass(PyObject* obj, PyObject* args)
 	Py_RETURN_NONE;
 }
 
-
-PyObject* JPypeJavaArray::setJavaArrayClass(PyObject* self, PyObject* arg)
-{
-	try {
-		PyObject* t;
-		JPyArg::parseTuple(arg, "O", &t);
-		hostEnv->setJavaArrayClass(t);
-
-		Py_RETURN_NONE;
-	}
-	PY_STANDARD_CATCH
-
-	return NULL;
-}
-
-PyObject* JPypeJavaArray::setGetJavaArrayClassMethod(PyObject* self, PyObject* arg)
-{
-	try {
-		PyObject* t;
-		JPyArg::parseTuple(arg, "O", &t);
-		hostEnv->setGetJavaArrayClassMethod(t);
-
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-	PY_STANDARD_CATCH
-
-	return NULL;
-}
-
 PyObject* JPypeJavaArray::getArrayLength(PyObject* self, PyObject* arg)
 {
 	try {

--- a/native/python/jpype_javaclass.cpp
+++ b/native/python/jpype_javaclass.cpp
@@ -17,55 +17,6 @@
 
 #include <jpype_python.h>  
 
-PyObject* JPypeJavaClass::setJavaLangObjectClass(PyObject* self, PyObject* arg)
-{
-	try {
-		PyObject* t;
-		JPyArg::parseTuple(arg, "O", &t);
-		hostEnv->setJavaLangObjectClass(t);
-
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-	PY_STANDARD_CATCH
-
-	return NULL;
-}
-
-PyObject* JPypeJavaClass::setGetClassMethod(PyObject* self, PyObject* arg)
-{
-	try {
-		PyObject* t;
-		JPyArg::parseTuple(arg, "O", &t);
-		hostEnv->setGetJavaClassMethod(t);
-
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-	PY_STANDARD_CATCH
-
-	return NULL;
-}
-
-
-PyObject* JPypeJavaClass::setSpecialConstructorKey(PyObject* self, PyObject* arg)
-{
-	try {
-		PyObject* t;
-		JPyArg::parseTuple(arg, "O", &t);
-		hostEnv->setSpecialConstructorKey(t);
-
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-	PY_STANDARD_CATCH
-
-	return NULL;
-}
-
 PyObject* JPypeJavaClass::findClass(PyObject* obj, PyObject* args)
 {
 	TRACE_IN("JPypeModule::findClass");

--- a/native/python/jpype_module.cpp
+++ b/native/python/jpype_module.cpp
@@ -403,3 +403,55 @@ PyObject* JPypeModule::setConvertStringObjects(PyObject* obj, PyObject* args)
 
 	return NULL;
 }
+
+/** Set a Jpype Resource.
+ *
+ * JPype needs to know about a number of python objects to function
+ * properly. These resources are set in the initialization methods
+ * as those resources are created in python. 
+ */
+PyObject* JPypeModule::setResource(PyObject* self, PyObject* arg)
+{	
+	try {
+		char* tname;
+		PyObject* value;
+		JPyArg::parseTuple(arg, "sO", &tname, &value);
+		string name = tname;
+
+		if (name == "WrapperClass")
+			hostEnv->setWrapperClass(value);
+		else if (name == "StringWrapperClass")
+			hostEnv->setStringWrapperClass(value);
+		else if (name == "ProxyClass")
+			hostEnv->setProxyClass(value);
+		else if (name == "JavaExceptionClass")
+			hostEnv->setJavaExceptionClass(value);
+
+		// Base class for JavaClass, used to check isInstance()
+		else if (name == "JavaClass")
+			hostEnv->setPythonJavaClass(value);
+    // Base class for JavaObject wrappers, used to check isInstance()
+		else if (name == "JavaObject")
+			hostEnv->setPythonJavaObject(value);
+
+		else if (name == "GetClassMethod")
+			hostEnv->setGetJavaClassMethod(value);
+		else if (name == "SpecialConstructorKey")
+			hostEnv->setSpecialConstructorKey(value);
+		else if (name == "JavaArrayClass")
+			hostEnv->setJavaArrayClass(value);
+		else if (name == "GetJavaArrayClassMethod")
+			hostEnv->setGetJavaArrayClassMethod(value);
+		else
+		{
+			PyErr_SetString(PyExc_RuntimeError, "Unknown jpype resource");
+			return NULL;
+		}
+
+		Py_RETURN_NONE;
+	}
+	PY_STANDARD_CATCH
+
+	return NULL;
+}
+

--- a/native/python/jpype_python.cpp
+++ b/native/python/jpype_python.cpp
@@ -24,53 +24,6 @@
 #endif
 
 PythonHostEnvironment* hostEnv;
-
-PyObject* JPypeJavaWrapper::setWrapperClass(PyObject* self, PyObject* arg)
-{
-	try {
-		PyObject* t;
-		JPyArg::parseTuple(arg, "O", &t);
-		hostEnv->setWrapperClass(t);
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-	PY_STANDARD_CATCH
-
-	return NULL;
-}
-
-PyObject* JPypeJavaWrapper::setStringWrapperClass(PyObject* self, PyObject* arg)
-{
-	try {
-		PyObject* t;
-		JPyArg::parseTuple(arg, "O", &t);
-		hostEnv->setStringWrapperClass(t);
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-	PY_STANDARD_CATCH
-
-	return NULL;
-}
-
-
-PyObject* JPypeJavaProxy::setProxyClass(PyObject* self, PyObject* arg)
-{
-	try {
-		PyObject* t;
-		JPyArg::parseTuple(arg, "O", &t);
-		hostEnv->setProxyClass(t);
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-	PY_STANDARD_CATCH
-
-	return NULL;
-}
-
 PyObject* convertToJValue(PyObject* self, PyObject* arg)
 {
 	if (! JPEnv::isInitialized())
@@ -149,21 +102,6 @@ PyObject* JPypeJavaProxy::createProxy(PyObject*, PyObject* arg)
 	return NULL;
 }
 
-static PyObject* setJavaExceptionClass(PyObject* self, PyObject* arg)
-{
-	try {
-		PyObject* t;
-		JPyArg::parseTuple(arg, "O", &t);
-		hostEnv->setJavaExceptionClass(t);
-
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-	PY_STANDARD_CATCH
-
-	return NULL;
-}
-
 static PyMethodDef jpype_methods[] = 
 {  
   {"isStarted", (PyCFunction)&JPypeModule::isStarted, METH_NOARGS, ""},
@@ -171,6 +109,7 @@ static PyMethodDef jpype_methods[] =
   {"attach", &JPypeModule::attach, METH_VARARGS, ""},
   {"shutdown", (PyCFunction)&JPypeModule::shutdown, METH_NOARGS, ""},
   {"findClass", &JPypeJavaClass::findClass, METH_VARARGS, ""},
+  {"setResource", &JPypeModule::setResource, METH_VARARGS, ""},
 
   {"synchronized", &JPypeModule::synchronized, METH_VARARGS, ""},
   {"isThreadAttachedToJVM", (PyCFunction)&JPypeModule::isThreadAttached, METH_NOARGS, ""}, 
@@ -181,18 +120,7 @@ static PyMethodDef jpype_methods[] =
   {"startReferenceQueue", &JPypeModule::startReferenceQueue, METH_VARARGS, ""},
   {"stopReferenceQueue", (PyCFunction)&JPypeModule::stopReferenceQueue, METH_NOARGS, ""},
 
-  {"setJavaLangObjectClass",   &JPypeJavaClass::setJavaLangObjectClass, METH_VARARGS, ""},
-  {"setGetClassMethod",        &JPypeJavaClass::setGetClassMethod, METH_VARARGS, ""},
-  {"setSpecialConstructorKey", &JPypeJavaClass::setSpecialConstructorKey, METH_VARARGS, ""},
-  
-  {"setJavaArrayClass", &JPypeJavaArray::setJavaArrayClass, METH_VARARGS, ""},
-  {"setGetJavaArrayClassMethod", &JPypeJavaArray::setGetJavaArrayClassMethod, METH_VARARGS, ""},
-
-  {"setWrapperClass", &JPypeJavaWrapper::setWrapperClass, METH_VARARGS, ""},
-  {"setProxyClass", &JPypeJavaProxy::setProxyClass, METH_VARARGS, ""},
   {"createProxy", &JPypeJavaProxy::createProxy, METH_VARARGS, ""},
-  {"setStringWrapperClass", &JPypeJavaWrapper::setStringWrapperClass, METH_VARARGS, ""},
-
 
   {"convertToJValue", &convertToJValue, METH_VARARGS, ""},
 
@@ -203,8 +131,6 @@ static PyMethodDef jpype_methods[] =
   {"getArraySlice", &JPypeJavaArray::getArraySlice, METH_VARARGS, ""},
   {"setArraySlice", &JPypeJavaArray::setArraySlice, METH_VARARGS, ""},
   {"newArray", &JPypeJavaArray::newArray, METH_VARARGS, ""},
-
-  {"setJavaExceptionClass", &setJavaExceptionClass, METH_VARARGS, ""},
 
   {"convertToDirectBuffer", &JPypeJavaNio::convertToDirectBuffer, METH_VARARGS, ""},
 

--- a/native/python/py_hostenv.cpp
+++ b/native/python/py_hostenv.cpp
@@ -222,13 +222,7 @@ JPMethod* PythonHostEnvironment::asMethod(HostRef* ref)
 bool PythonHostEnvironment::isObject(HostRef* ref)
 {
 	PyObject* obj = UNWRAP(ref);
-
-	if (JPyObject::isInstance(obj, m_JavaLangObject))
-	{
-		return true;
-	}
-
-	return false;
+  return JPyObject::isInstance(obj, m_PythonJavaObject);
 }
 
 JPObject* PythonHostEnvironment::asObject(HostRef* m)
@@ -277,14 +271,7 @@ HostRef* PythonHostEnvironment::newObject(JPObject* obj)
 bool PythonHostEnvironment::isClass(HostRef* ref)
 {
 	PyObject* self = UNWRAP(ref);
-
-	if (! JPyType::check(self)) 
-	{
-		// If its not a type ... it can;t be a java type
-		return false;
-	}
-
-	return JPyType::isSubclass(self, m_JavaLangObject);
+	return JPyObject::isInstance(self, m_PythonJavaClass);
 }
 
 HostRef* PythonHostEnvironment::newClass(JPClass* m)

--- a/native/python/py_hostenv.cpp
+++ b/native/python/py_hostenv.cpp
@@ -222,7 +222,7 @@ JPMethod* PythonHostEnvironment::asMethod(HostRef* ref)
 bool PythonHostEnvironment::isObject(HostRef* ref)
 {
 	PyObject* obj = UNWRAP(ref);
-  return JPyObject::isInstance(obj, m_PythonJavaObject);
+	return JPyObject::isInstance(obj, m_PythonJavaObject);
 }
 
 JPObject* PythonHostEnvironment::asObject(HostRef* m)

--- a/native/python/pythonenv.cpp
+++ b/native/python/pythonenv.cpp
@@ -501,11 +501,7 @@ bool JPyType::check(PyObject* obj)
 
 bool JPyType::isSubclass(PyObject* o1, PyObject* o2)
 {
-	if (PyType_IsSubtype((PyTypeObject*)o1, (PyTypeObject*)o2))
-	{
-		return true;
-	}
-	return false;
+	return PyType_IsSubtype((PyTypeObject*)o1, (PyTypeObject*)o2);
 }
 
 void JPyHelper::dumpSequenceRefs(PyObject* seq, const char* comment)

--- a/test/harness/jpype/reflect/Annotation.java
+++ b/test/harness/jpype/reflect/Annotation.java
@@ -1,0 +1,17 @@
+package jpype.reflect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value =
+{
+  ElementType.METHOD
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Annotation
+{
+  public String value();
+}
+

--- a/test/harness/jpype/reflect/ReflectionTest.java
+++ b/test/harness/jpype/reflect/ReflectionTest.java
@@ -1,0 +1,27 @@
+package jpype.reflect;
+
+class ReflectionTest
+{
+	public String publicField = "public";
+	private String privateField ="private";
+
+	public ReflectionTest()
+	{
+	}
+
+	public String publicMethod()
+	{
+		return "public";
+	}
+
+	private String privateMethod()
+	{
+		return "private";
+	}
+
+	@Annotation("annotation")
+	public void annotatedMethod()
+	{
+	}
+}
+

--- a/test/jpypetest/reflect.py
+++ b/test/jpypetest/reflect.py
@@ -1,0 +1,68 @@
+#*****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#*****************************************************************************
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import sys
+import jpype
+from jpype import JPackage, JArray, JByte, java
+from . import common
+
+if sys.version > '3':
+    unicode = str
+
+class ReflectCase(common.JPypeTestCase):
+
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+        self.test1 = jpype.JClass('jpype.overloads.Test1')()
+        self.Reflect = jpype.JClass('jpype.reflect.ReflectionTest')
+        self.Annotation = jpype.JClass('jpype.reflect.Annotation')
+
+    def testClass(self):
+        t = jpype.JClass('java.lang.Object')
+        obj = self.Reflect()
+        self.assertEquals('Class', self.test1.testClassVsObject(self.Reflect))
+        self.assertEquals('Class', self.test1.testClassVsObject(self.Reflect.class_))
+        self.assertEquals('Class', self.test1.testClassVsObject(obj.getClass()))
+        self.assertEquals('Class', self.test1.testClassVsObject(obj.__class__.class_))
+
+    def testAnnotation(self):
+        method = self.Reflect.class_.getMethod('annotatedMethod')
+        annotation = method.getAnnotation(self.Annotation)
+        self.assertEquals('annotation', annotation.value())
+
+    def testCallPublicMethod(self):
+        method = self.Reflect.class_.getMethod('publicMethod')
+        obj = self.Reflect()
+        self.assertEquals('public', method.invoke(obj))
+
+    def testCallPrivateMethod(self):
+        method = self.Reflect.class_.getDeclaredMethod('privateMethod')
+        obj = self.Reflect()
+        self.assertEquals('private', method.invoke(obj))
+
+    def testAccessPublicField(self):
+        field = self.Reflect.class_.getField('publicField')
+        obj = self.Reflect()
+        self.assertEquals('public', field.get(obj))
+
+    def testAccessPrivateField(self):
+        field = self.Reflect.class_.getDeclaredField('privateField')
+        obj = self.Reflect()
+        self.assertEquals('private', field.get(obj))


### PR DESCRIPTION
* This patch exposes java.lang.Class as Foo.class_ for types and foo.getClass() for objects.  
* It allows full use of reflection to access annotations, private fields and private methods.   
* It reorders the customizers so that PropertyCustomizer is applied to java.lang.Object and java.lang.Exception.
* It unifies a large number of mostly copy and paste methods under setResource.
* It removes the redundant class JPClassType.
* It patches a warning on comparison of unsigned to signed
* It simplifies a handful of comparison tests.

See issues #247 and #237 for details.

