### PR TITLE
Describe exception when tracing is enabled

### DIFF
--- a/native/common/jp_javaenv.cpp
+++ b/native/common/jp_javaenv.cpp
@@ -286,13 +286,17 @@ jint JPJavaEnv::Throw(jthrowable th)
 }
 
 jthrowable JPJavaEnv::ExceptionOccurred()
-{   
+{
 	jthrowable res;
-    JNIEnv* env = getJNIEnv();
+	JNIEnv* env = getJNIEnv();
 
 	res = env->functions->ExceptionOccurred(env);
- 
-    return res;
+#ifdef TRACING
+	if(res) {
+		env->functions->ExceptionDescribe(env);
+	}
+#endif
+	return res;
 }
 
 jobject JPJavaEnv::NewDirectByteBuffer(void* address, jlong capacity)


### PR DESCRIPTION
When the TRACING compile flag is enabled, use the JNI ``ExceptionDescribe()`` method to have more information about what happens.