### PR TITLE
Added support to check for architecture differences betweeen jvm and python

### DIFF
--- a/jpype/_jvmfinder.py
+++ b/jpype/_jvmfinder.py
@@ -110,6 +110,14 @@ class JVMFinder(object):
                         yield path
                         break
 
+    def check(self, jvm):
+        """
+        Check if the jvm is valid for this architecture.
+
+        This method should be overriden for each architecture.
+        :raise JVMNotSupportedException: If the jvm is not supported.
+        """
+        pass
 
     def get_jvm_path(self):
         """
@@ -121,11 +129,14 @@ class JVMFinder(object):
         for method in self._methods:
             try:
                 jvm = method()
+                self.check(jvm)
             except NotImplementedError:
                 # Ignore missing implementations
                 pass
             except JVMNotFoundException:
                 # Ignore not successful methods
+                pass
+            except JVMNotSupportedException:
                 pass
 
             else:


### PR DESCRIPTION
Patch for #241 

I still don't have access to make the patterns for Mac or Linux, but the problem bit me on Windows so I figured it was time to put the check in place.  

This patch adds a new call to the jvm finder that checks if the jvm is valid prior to returning it.  The check procedure can throw a JVMNotSupportedException if the jvm and the python architecture don't match so that the finder will continue to look for a valid jvm.  It will now properly throw a failure if the found jvm is not supported but it doesn't report the exception string that would be useful for debugging.  

We can add checks for other architectures and have them implement the check method.  

This patch is a work in progress as I have not checked out the other issues that were causing appveyor failures.