### PR TITLE
Ignore unrecognized

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 This changelog *only* contains changes from the *first* pypi release (0.5.4.3) onwards.
 
 - **Next version - unreleased**
+  - Changed startJVM() to report errors on unrecognized options by default.
+    Use `ignoreUnrecognized=True` to get previous behavior.
+
   - Java reference counting has been converted to use JNI 
     PushLocalFrame/PopLocalFrame.  Several resource leaks
     were removed.

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -60,14 +60,17 @@ def _initialize():
 def isJVMStarted() :
     return _jpype.isStarted()
 
-def startJVM(jvm, *args):
+def startJVM(jvm, *args, ignoreUnrecognized=False):
     """
     Starts a Java Virtual Machine
 
-    :param jvm:  Path to the jvm library file (libjvm.so, jvm.dll, ...)
-    :param args: Arguments to give to the JVM
+    Args:
+      jvm (str):  Path to the jvm library file (libjvm.so, jvm.dll, ...)
+      *args (str[]): Arguments to give to the JVM
+      ignoreUnrecognized (Optional[bool]): option to jvm to return an 
+        error if a jvm argument is invalid.  (Default False)
     """
-    _jpype.startup(jvm, tuple(args), True)
+    _jpype.startup(jvm, tuple(args), ignoreUnrecognized)
     _initialize()
 
     # start the reference daemon thread


### PR DESCRIPTION
Change in default behavior to force unrecognized options to issue an exception.  