### PR TITLE
Fix bug in the check architecture command.

### DIFF
--- a/jpype/_jvmfinder.py
+++ b/jpype/_jvmfinder.py
@@ -129,7 +129,10 @@ class JVMFinder(object):
         for method in self._methods:
             try:
                 jvm = method()
-                self.check(jvm)
+
+                # If found check the architecture 
+                if jvm:
+                    self.check(jvm)
             except NotImplementedError:
                 # Ignore missing implementations
                 pass


### PR DESCRIPTION
There was a case in which the None was passed to the check architecture resulting in a failure.  Rather than forcing all check architectures to be robust against None I added a check for None before calling the check.