### PR TITLE
Fix for JPackage when accessing python privates.

### DIFF
--- a/jpype/_jpackage.py
+++ b/jpype/_jpackage.py
@@ -25,7 +25,9 @@ class JPackage(object):
     def __getattribute__(self, n):
         try:
             return object.__getattribute__(self, n)
-        except:
+        except AttributeError as ex:
+            if n.startswith("__"):
+                raise ex
             # not found ...
 
             # perhaps it is a class?


### PR DESCRIPTION
Simple patch to disable the incorrect warning message when accessing python private members like `__base__` in JPackage prior to starting the jvm.  