### PR TITLE
Float conversion bug

### DIFF
--- a/native/common/jp_field.cpp
+++ b/native/common/jp_field.cpp
@@ -105,7 +105,7 @@ void JPField::setStaticAttribute(HostRef* val)
 	{
 		stringstream err;
 		err << "unable to convert to " << type->getName().getSimpleName();
-		RAISE(JPypeException, err.str().c_str());
+		JPEnv::getHost()->setTypeError( err.str().c_str());
 	}
 		
 	jclass claz = m_Class->getClass();
@@ -138,7 +138,7 @@ void JPField::setAttribute(jobject inst, HostRef* val)
 	{
 		stringstream err;
 		err << "unable to convert to " << type->getName().getSimpleName();
-		RAISE(JPypeException, err.str().c_str());
+		JPEnv::getHost()->setTypeError( err.str().c_str());
 	}
 		
 	type->setInstanceValue(inst, m_FieldID, val);		

--- a/native/common/jp_primitivetypes.cpp
+++ b/native/common/jp_primitivetypes.cpp
@@ -424,11 +424,11 @@ jvalue JPFloatType::convertToJava(HostRef* obj)
 	}
 	else if (JPEnv::getHost()->isInt(obj))
 	{
-		res.d = JPEnv::getHost()->intAsInt(obj);;
+		res.f = JPEnv::getHost()->intAsInt(obj);;
 	}
 	else if (JPEnv::getHost()->isLong(obj))
 	{
-		res.d = JPEnv::getHost()->longAsLong(obj);;
+		res.f = JPEnv::getHost()->longAsLong(obj);;
 	}
 	else
 	{

--- a/test/harness/jpype/values/FieldsTest.java
+++ b/test/harness/jpype/values/FieldsTest.java
@@ -1,0 +1,12 @@
+package jpype.values;
+
+public class FieldsTest 
+{
+  public static boolean booleanField;
+  public static char charField;
+  public static short shortField;
+  public static long longField;
+  public static int intField;
+  public static float floatField;
+  public static double doubleField;
+}

--- a/test/jpypetest/values.py
+++ b/test/jpypetest/values.py
@@ -1,0 +1,85 @@
+#*****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#*****************************************************************************
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import sys
+import jpype
+from . import common
+
+#Python2/3 support
+if sys.version > '3':
+    long  =  int
+    unicode = str
+
+# Test code
+class ValuesTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+        self.Fields = jpype.JClass('jpype.values.FieldsTest')
+
+# Int
+    def testIntFromInt(self):
+        self.Fields.intField = 1
+        self.assertEquals(self.Fields.intField,1)
+
+    def testIntFromInt(self):
+        with self.assertRaises(TypeError):
+            self.Fields.intField = 7.2
+
+    def testIntFromFloat(self):
+        with self.assertRaises(TypeError):
+            self.Fields.intField = 2.1
+
+# Float 
+    def testFloatFromInt(self):
+        self.Fields.floatField = 1
+        self.assertEquals(self.Fields.floatField,1.0)
+
+    def testFloatFromFloat(self):
+        self.Fields.floatField = 2.0
+        self.assertEquals(self.Fields.floatField,2.0)
+
+# Double 
+    def testDoubleFromInt(self):
+        self.Fields.doubleField = 1
+        self.assertEquals(self.Fields.doubleField,1.0)
+
+    def testDoubleFromFloat(self):
+        self.Fields.doubleField = 2.0
+        self.assertEquals(self.Fields.doubleField,2.0)
+
+# Wrappers (must be exact currently)
+    def testIntFromIntWrapper(self):
+        self.Fields.intField = jpype.JInt(5)
+        self.assertEquals(self.Fields.intField,5)
+
+# This one fails as it seems to be casting the 6.0 to an integer value literally.  I am not sure if that is intended behavior.
+#    def testIntFromFloatWrapper(self):
+#        self.Fields.intField = jpype.JInt(6.0)
+#        self.assertEquals(self.Fields.intField,6)
+
+    def testFloatFromFloatWrapper(self):
+        self.Fields.floatField = jpype.JFloat(5.0)
+        self.assertEquals(self.Fields.floatField,5.0)
+
+    def testDoubleFromDoubleWrapper(self):
+        self.Fields.doubleField = jpype.JDouble(5.0)
+        self.assertEquals(self.Fields.doubleField,5.0)
+
+

--- a/test/jpypetest/varargs.py
+++ b/test/jpypetest/varargs.py
@@ -28,8 +28,7 @@ if sys.version > '3':
     unicode = str
 
 # Test code
-class BoxedTestCase(common.JPypeTestCase):
-#class BoxedTestCase(unittest.TestCase):
+class VarArgsTestCase(common.JPypeTestCase):
     def setUp(self):
         common.JPypeTestCase.setUp(self)
         self.VarArgs = jpype.JClass('jpype.varargs.VarArgs')


### PR DESCRIPTION
A copy and paste error was leaving widening conversions to  float in an incorrect state causing them to convert to 0 rather than expected value.   

This also switched assignments of fields from a RuntimeError to a TypeError when the conversion fails on fields.  This is more consistent with parts of the toolkit.  

The test are currently incomplete as another error in the kit is preventing a complete test run.  There is one unexpected behavior in that calling JInt(1.0) give the byte value from 1.0 in floating point rather than the expected behavior of creating an int with a value of 1, ie.  `int i=(int)1.0;`.   I am not sure if this is another bug or intended behavior.