### PR TITLE
Fix bug with ipython imports

### DIFF
--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -142,7 +142,7 @@ class _JImport(object):
     # Module requirements
     __doc__ = None
     __loader__ = None
-    __path__ = "<java>"
+    __path__ = []
     __package__ = "java"
 
     def __init__(self, name):


### PR DESCRIPTION
A certain module in ipython scientific package is requiring all modules to use __path__ as either NoneType or a list.  Another module is requiring that path does is not None.  Changed the __path__ to an empty list to remove the interaction between jpype and ipython module.