### PR TITLE
Remove extra local ref.

### DIFF
--- a/native/common/include/jp_array.h
+++ b/native/common/include/jp_array.h
@@ -53,7 +53,7 @@ public :
 
 	jobject getObject()
 	{
-		return JPEnv::getJava()->NewLocalRef(m_Object);
+		return m_Object;
 	}
 
 public : // Wrapper

--- a/native/common/include/jp_object.h
+++ b/native/common/include/jp_object.h
@@ -32,7 +32,7 @@ public :
 
 	jobject      getObject()
 	{
-		return JPEnv::getJava()->NewLocalRef(m_Object);
+		return m_Object; 
 	}
 
 	JCharString toString();

--- a/native/common/jp_array.cpp
+++ b/native/common/jp_array.cpp
@@ -128,7 +128,7 @@ JPType* JPArray::getType()
 jvalue  JPArray::getValue()
 {
 	jvalue val;
-	val.l = JPEnv::getJava()->NewLocalRef(m_Object);
+	val.l = m_Object;
 	return val;
 }
 JCharString JPArray::toString()

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -387,6 +387,8 @@ jobject JPClass::buildObjectWrapper(HostRef* obj)
 
 	JPObject* pobj = newInstance(args);
 	jobject out = pobj->getObject();
+	// We need to keep a reference to the object here as our global reference is about to die
+	out = JPEnv::getJava()->NewLocalRef(out); 
 	delete pobj;
 
 	return frame.keep(out);
@@ -411,7 +413,7 @@ jvalue JPClass::convertToJava(HostRef* obj)
 	if (JPEnv::getHost()->isObject(obj))
 	{
 		JPObject* ref = JPEnv::getHost()->asObject(obj);
-		res.l = frame.keep(ref->getObject());
+		res.l = ref->getObject();
 		return res;
 	}
 

--- a/native/common/jp_primitivetypes.cpp
+++ b/native/common/jp_primitivetypes.cpp
@@ -27,6 +27,8 @@ jobject JPPrimitiveType::convertToJavaObject(HostRef* obj)
 
 	JPObject* o = c->newInstance(args);
 	jobject res = o->getObject(); 
+	// We need to keep a local reference here
+	res = JPEnv::getJava()->NewLocalRef(res); 
 	delete o;
 	return frame.keep(res);
 }

--- a/native/python/py_hostenv.cpp
+++ b/native/python/py_hostenv.cpp
@@ -542,7 +542,7 @@ jvalue PythonHostEnvironment::getWrapperValue(PyObject* obj)
 	if (name.isObjectType())
 	{
 		jvalue res;
-		res.l = JPEnv::getJava()->NewLocalRef(v->l); // FIXME This is bad, nothing cleans it up
+		res.l = v->l; 
 		return res;
 	}
 	return *v;


### PR DESCRIPTION
This patch removes all unnecessary LocalRef in an attempt to isolate problems reported with threading.  It has minor performance improvement as the extra referencing required calls to get env.