### PR TITLE
Fix #331: Don't call Py_Initialize() in PyInit__jpype() to support Python 3.7

### DIFF
--- a/native/python/jpype_python.cpp
+++ b/native/python/jpype_python.cpp
@@ -153,7 +153,6 @@ PyMODINIT_FUNC PyInit__jpype()
 PyMODINIT_FUNC init_jpype()
 #endif
 {
-	Py_Initialize();
 	PyEval_InitThreads();
 	  
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
Since Python 3.7, calling Py_Initialize() twice triggers a fatal error.

Simply remove the Py_Initialize() call from PyInit__jpype(), since it is just useless.